### PR TITLE
fix: compute checksums after signing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,16 +91,6 @@ jobs:
         ls -lh wsc-*.wasm
         file wsc-*.wasm
 
-    - name: Create SHA256 checksums
-      run: |
-        sha256sum wsc-component.wasm > wsc-component.wasm.sha256
-        cat wsc-component.wasm.sha256
-
-        if [ -f wsc-cli.wasm ]; then
-          sha256sum wsc-cli.wasm > wsc-cli.wasm.sha256
-          cat wsc-cli.wasm.sha256
-        fi
-
     - name: Build wsc Native CLI
       run: |
         echo "Building wsc native CLI for signing..."
@@ -140,6 +130,17 @@ jobs:
         echo "  - Identity: GitHub Actions OIDC"
         echo "  - Certificate: Short-lived from Fulcio"
         echo "  - Transparency: Logged in Rekor"
+
+    - name: Create SHA256 checksums
+      run: |
+        # Create checksums AFTER signing so they match the signed files
+        sha256sum wsc-component.wasm > wsc-component.wasm.sha256
+        cat wsc-component.wasm.sha256
+
+        if [ -f wsc-cli.wasm ]; then
+          sha256sum wsc-cli.wasm > wsc-cli.wasm.sha256
+          cat wsc-cli.wasm.sha256
+        fi
 
     - name: Log in to Container Registry
       uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Move SHA256 checksum creation to AFTER wsc keyless signing
- Ensures checksums match the signed artifacts users download

## Problem
The v0.4.0 release has mismatched checksums because they were computed before signing modified the files.

## Test plan
- [ ] Watch CI pass
- [ ] Verify next release has matching checksums