### PR TITLE
fix: prevent OOM via malicious certificate count in signature parsing

### DIFF
--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -61,6 +61,9 @@ pub enum WSError {
     #[error("Too many signatures (max: {0})")]
     TooManySignatures(usize),
 
+    #[error("Too many certificates (max: {0})")]
+    TooManyCertificates(usize),
+
     #[error("Usage error: {0}")]
     UsageError(&'static str),
 


### PR DESCRIPTION
## Summary

- Add `MAX_CERTIFICATES` limit (16) to prevent OOM attacks via crafted input
- Found via fuzz testing: 17-byte input triggered 40GB allocation attempt
- Follows existing pattern for `MAX_HASHES` and `MAX_SIGNATURES`

## Security Impact

A malicious WASM module with a crafted signature section could cause the parser to attempt allocating billions of bytes by claiming an enormous certificate count before any certificate data was validated.

## Test plan

- [x] Unit tests for certificate limit (`test_signature_for_hashes_too_many_certificates`)
- [x] Regression test for extreme counts (`test_signature_for_hashes_extreme_certificate_count`)
- [x] Verified fix against original fuzz crash file
- [x] All existing tests pass