### PR TITLE
fix: add wsc-attestation to publish script dependency order

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -11,7 +11,8 @@ use std::thread;
 use std::time::Duration;
 
 // List of crates to publish in dependency order
-const CRATES_TO_PUBLISH: &[&str] = &["wsc", "wsc-cli"];
+// wsc-attestation MUST be first: wsc depends on it, wsc-cli depends on wsc
+const CRATES_TO_PUBLISH: &[&str] = &["wsc-attestation", "wsc", "wsc-cli"];
 
 struct Workspace {
     version: String,
@@ -43,6 +44,10 @@ fn main() {
     let ws = Workspace {
         version: ws_version,
     };
+
+    // Add attestation crate (must be published first - wsc depends on it)
+    let attestation_crate = read_crate(Some(&ws), "./src/attestation/Cargo.toml".as_ref());
+    crates.push(attestation_crate);
 
     // Add main library crate
     let lib_crate = read_crate(Some(&ws), "./src/lib/Cargo.toml".as_ref());


### PR DESCRIPTION
## Summary

The Release workflow fails because `scripts/publish.rs` only publishes `wsc` and `wsc-cli`, but not `wsc-attestation`. Since `wsc` depends on `wsc-attestation = "^0.5.0"` and crates.io only has `0.4.1`, cargo publish fails.

- Add `wsc-attestation` to `CRATES_TO_PUBLISH` (first in order)
- Load attestation crate manifest before lib and CLI crates

## Test plan

- [ ] `rustc scripts/publish.rs` compiles
- [ ] Release workflow succeeds after merge