### PR TITLE
fix: use CRATES_IO_TOKEN and macos-15-intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,9 @@ jobs:
             artifact_name: wsc
             asset_name: wsc-linux-aarch64
             cross: true
-          # macOS x86_64 (Intel)
+          # macOS x86_64 (Intel) - using macos-15-intel (macos-13 deprecated Dec 2025)
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             artifact_name: wsc
             asset_name: wsc-macos-x86_64
           # macOS aarch64 (Apple Silicon)
@@ -130,7 +130,7 @@ jobs:
     - name: Publish crates to crates.io
       run: ./publish publish
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   build-and-release:
     name: Build & Release WASM Component


### PR DESCRIPTION
Quick fix for release workflow:

- Change secret from CARGO_REGISTRY_TOKEN to CRATES_IO_TOKEN (matches org-wide token)
- Use macos-15-intel instead of deprecated macos-13 for Intel builds

Sources:
- [macOS 13 deprecation](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [macos-15-intel available](https://github.com/actions/runner-images/issues/13045)