### PR TITLE
chore: release v0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
-authors = ["Frank Denis <github@pureftpd.org>"]
+authors = ["Frank Denis <github@pureftpd.org>", "Ralf Anton Beier <ralf_beier@me.com>"]
 license = "MIT"
 repository = "https://github.com/pulseengine/wsc"
 


### PR DESCRIPTION
## Release v0.5.1

- Bump version to 0.5.1
- Add Ralf Anton Beier as co-author

### Release Artifacts

**Native CLI Binaries:**
- Linux x86_64 (standard and TPM2-enabled)
- Linux aarch64
- macOS x86_64 (Intel) 
- macOS aarch64 (Apple Silicon)
- Windows x86_64

**WebAssembly Components:**
- wsc-component.wasm (WIT interface)
- wsc-cli.wasm (WASI binary)

**Rust Crates:**
- wsc-attestation
- wsc
- wsc-cli