### PR TITLE
fix: only publish crates on tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,8 @@ jobs:
         retention-days: 1
 
   publish-crates:
-    if: github.repository == 'pulseengine/wsc'
+    # Only publish on tag pushes to prevent race condition with main branch
+    if: github.repository == 'pulseengine/wsc' && github.ref_type == 'tag'
     name: Publish Rust Crates
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Prevents race condition where main branch push publishes crates before the tag-triggered workflow runs, causing the tag workflow to fail with 'crate already exists' error.

## Changes

- Added `github.ref_type == 'tag'` condition to `publish-crates` job
- This ensures crates are only published when a version tag is pushed, not on every main branch commit

## Context

During the v0.5.1 release, the workflow triggered twice:
1. On main branch push (from PR merge) - published crates
2. On tag push - failed because crates already existed

This fix ensures only tag pushes trigger crate publishing.