### PR TITLE
ci: install Nix in release workflow for Bazel Rocq toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential gcc g++
 
+    # Nix is required for rules_rocq_rust toolchain registered in MODULE.bazel
+    # (Bazel evaluates all toolchains during loading, even for non-Rocq builds)
+    - name: Install Nix
+      uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
     - name: Setup Bazel
       uses: bazel-contrib/setup-bazel@0.15.0
       with:


### PR DESCRIPTION
## Summary

Fix the `Release` workflow which has been failing since Rocq was introduced. The `build-and-release` job invokes `bazel build //src/component:signing_lib_release`, which triggers Bazel's loading phase to evaluate all toolchains registered in MODULE.bazel. `rules_rocq_rust` uses `nixpkgs_package` which fails hard with `nix-build not found` when Nix is absent.

## Fix

Add `cachix/install-nix-action@v30` to the release workflow's `build-and-release` job — same pattern already used by `formal-verification.yml` and `rust.yml`.

## Test plan
- [x] Local diff reviewed
- [ ] CI pipeline (this PR exercises the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)