### PR TITLE
ci: tolerate wsc-cli.wasm sign failure in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,14 +259,23 @@ jobs:
         # Create a detached signature for verification
         mv wsc-component.signed.wasm wsc-component.wasm
 
-        # Sign the CLI WASM if it exists
+        # Sign the CLI WASM if it exists and is a parseable core module / component.
+        # The CLI WASM is built with wasm32-wasip2 which produces a format that
+        # wsc's own parser does not currently recognize. This is a known limitation
+        # and the CLI WASM is an optional artifact, so we tolerate sign failures.
         if [ -f wsc-cli.wasm ]; then
           echo "Signing wsc-cli.wasm..."
-          ./target/release/wsc sign --keyless \
-            --input-file wsc-cli.wasm \
-            --output-file wsc-cli.signed.wasm
-
-          mv wsc-cli.signed.wasm wsc-cli.wasm
+          if ./target/release/wsc sign --keyless \
+               --input-file wsc-cli.wasm \
+               --output-file wsc-cli.signed.wasm; then
+            mv wsc-cli.signed.wasm wsc-cli.wasm
+            echo "  ✅ wsc-cli.wasm signed"
+          else
+            echo "  ⚠️  wsc-cli.wasm could not be signed (parser does not yet"
+            echo "      support the wasm32-wasip2 output format). Removing"
+            echo "      unsigned CLI artifact from release."
+            rm -f wsc-cli.wasm wsc-cli.signed.wasm
+          fi
         fi
 
         echo "✅ WASM files signed with wsc (keyless)"


### PR DESCRIPTION
## Summary

Second fix for the Release workflow, after #84 fixed the Nix/Bazel loading issue.

## Problem

`wsc sign` fails with "Parse error" on `wsc-cli.wasm`:
- The CLI WASM is built with `--platforms=wasm32-wasip2`, producing a WASI preview2 component
- wsc's own WASM parser doesn't yet recognize this format
- The earlier build step already tolerates failure, but the sign step is strict

## Fix

Align sign step tolerance with the build step. If `wsc sign wsc-cli.wasm` fails, log a warning and remove the unsigned artifact. The primary `wsc-component.wasm` artifact still signs successfully.

## Follow-up

Extend wsc's WASM parser to handle wasm32-wasip2 output — tracked as a separate enhancement, not blocking release.

## Test plan
- [x] Workflow YAML reviewed
- [ ] Release workflow on main triggers after merge and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)