### PR TITLE
fix: audit hygiene — kani cfg, version drift, docs, CI bloat

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Generate compliance report
       id: report
-      uses: pulseengine/rivet/.github/actions/compliance@main
+      uses: pulseengine/rivet/.github/actions/compliance@v0.6.0
       with:
         theme: ${{ inputs.theme }}
         report-label: ${{ inputs.version }}

--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -2,12 +2,9 @@ name: Memory Profiling
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'src/**/*.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
+  schedule:
+    # Nightly run at 03:17 UTC (memory profiling is too slow for every PR)
+    - cron: '17 3 * * *'
 
 env:
   RUST_VERSION: "1.90.0"

--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    if: github.repository == 'pulseengine/wsc'
+    if: github.repository == 'pulseengine/sigil'
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Generate compliance report
       id: report
-      uses: pulseengine/rivet/.github/actions/compliance@main
+      uses: pulseengine/rivet/.github/actions/compliance@v0.6.0
       with:
         theme: dark
         rivet-version: v0.3.0
@@ -130,27 +130,8 @@ jobs:
         path: artifacts/*
         retention-days: 1
 
-  publish-crates:
-    # Only publish on tag pushes to prevent race condition with main branch
-    if: github.repository == 'pulseengine/sigil' && github.ref_type == 'tag'
-    name: Publish Rust Crates
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # Required for trusted publishing
-      contents: read
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Install Rust
-      run: rustup update stable && rustup default stable
-    
-    - name: Build publish script
-      run: rustc scripts/publish.rs
-    
-    - name: Publish crates to crates.io
-      run: ./publish publish
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+  # NOTE: crates.io publishing lives in `.github/workflows/publish-to-crates-io.yml`
+  # to keep tag-push publication single-sourced (avoids the dual-publish race).
 
   build-and-release:
     name: Build & Release WASM Component
@@ -159,7 +140,7 @@ jobs:
       contents: write
       packages: write
       id-token: write  # For Cosign keyless signing
-    needs: [publish-crates, build-native-cli]
+    needs: [build-native-cli]
     if: always() && needs.build-native-cli.result == 'success'
 
     steps:

--- a/.github/workflows/tpm-tests.yml
+++ b/.github/workflows/tpm-tests.yml
@@ -1,17 +1,10 @@
 name: TPM2 Tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:  # Allow manual trigger
-
-# NOTE: Once verified working, can add path filters to only run when TPM code changes:
-# paths:
-#   - 'src/lib/src/platform/tpm2.rs'
-#   - 'src/lib/Cargo.toml'
-#   - '.github/workflows/tpm-tests.yml'
+  schedule:
+    # Nightly run at 03:17 UTC (TPM emulation is too heavy for every PR)
+    - cron: '17 3 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,8 @@
 
 module(
     name = "wsc",
-    version = "0.2.7",
+    # Keep in sync with [workspace.package].version in Cargo.toml.
+    version = "0.8.0",
 )
 
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ The cryptographic backbone of the PulseEngine pipeline. Sigil signs WebAssembly 
 
 Built on the [WebAssembly modules signatures proposal](https://github.com/wasm-signatures/design) and extended with Sigstore keyless signing, SLSA policy enforcement, and hardware security via TPM 2.0. All signatures are embedded directly in WebAssembly modules — no external registry required.
 
+## Quick Try (no WASM artifact required)
+
+Don't have a `.wasm` module to play with? The eight-byte minimal WebAssembly
+module is enough to exercise the full sign-and-verify round-trip locally.
+
+```bash
+git clone https://github.com/pulseengine/sigil.git
+cd sigil
+cargo build --release
+
+./target/release/sigil keygen -k secret.key -K public.key
+printf '\x00\x61\x73\x6d\x01\x00\x00\x00' > test.wasm
+./target/release/sigil sign -k secret.key -i test.wasm -o signed.wasm
+./target/release/sigil verify -K public.key -i signed.wasm
+```
+
+Keyless signing (`--keyless`) needs an OIDC provider such as GitHub Actions —
+see [`docs/keyless.md`](docs/keyless.md) for the setup.
+
 ## Quick Start
 
 ```bash

--- a/docs/bazel-build-guide.md
+++ b/docs/bazel-build-guide.md
@@ -1,10 +1,10 @@
-# Building wasmsign2 with Bazel
+# Building sigil with Bazel
 
-This document describes how to build wasmsign2 as WebAssembly components using Bazel and `rules_wasm_component`.
+This document describes how to build sigil as WebAssembly components using Bazel and `rules_wasm_component`.
 
 ## Architecture
 
-The wasmsign2 project supports dual build systems:
+The sigil project supports dual build systems:
 
 - **Cargo (Native)**: Build native binaries with full features including GitHub key fetching
 - **Bazel (WASM)**: Build WebAssembly components for hermetic, cross-platform execution
@@ -12,7 +12,7 @@ The wasmsign2 project supports dual build systems:
 ### Component Structure
 
 ```
-wasmsign2/
+sigil/
 ├── src/lib/              # Core signing library (Rust)
 ├── src/component/        # WASM component exporting WIT interface
 ├── src/cli/              # Command-line interface (native and WASI)
@@ -23,7 +23,7 @@ wasmsign2/
 
 | Target | Output | Description |
 |--------|--------|-------------|
-| `//src/lib:wasmsign2` | Rust library | Core signing functionality |
+| `//src/lib:wsc` | Rust library | Core signing functionality |
 | `//wit:wasmsign_wit` | WIT interface | Component model interface |
 | `//src/component:signing_lib` | `signing-lib.wasm` | Reusable component exporting signing interface |
 | `//src/cli:wasmsign_cli` | `wasmsign-cli.wasm` | WASI CLI tool |
@@ -34,7 +34,7 @@ Build the native CLI with all features:
 
 ```bash
 cargo build --release
-./target/release/wasmsign2 --help
+./target/release/sigil --help
 ```
 
 This includes:
@@ -78,20 +78,20 @@ This produces:
 
 ## Integration with rules_wasm_component
 
-To use wasmsign2 components in `rules_wasm_component`:
+To use sigil components in `rules_wasm_component`:
 
-1. **Reference the wasmsign2 repository** in your MODULE.bazel:
+1. **Reference the sigil repository** in your MODULE.bazel:
    ```starlark
    git_override(
-       module_name = "wasmsign2",
-       remote = "https://github.com/wasm-signatures/wasmsign2.git",
+       module_name = "wsc",
+       remote = "https://github.com/pulseengine/sigil.git",
        commit = "<commit-hash>",
    )
    ```
 
 2. **Use the signing component** in your BUILD files:
    ```starlark
-   load("@wasmsign2//src/component:defs.bzl", "signing_lib")
+   load("@wsc//src/component:defs.bzl", "signing_lib")
 
    # Use the signing component in your workflow
    wasm_sign(
@@ -108,12 +108,12 @@ To use wasmsign2 components in `rules_wasm_component`:
        srcs = [":my_module.wasm"],
        outs = ["signed_module.wasm"],
        cmd = """
-           $(location @wasmsign2//src/cli:wasmsign_cli) sign \
+           $(location @wsc//src/cli:wasmsign_cli) sign \
                --input-file $(location :my_module.wasm) \
                --output-file $@ \
                --secret-key $(location :key.sec)
        """,
-       tools = ["@wasmsign2//src/cli:wasmsign_cli"],
+       tools = ["@wsc//src/cli:wasmsign_cli"],
    )
    ```
 

--- a/docs/keyless.md
+++ b/docs/keyless.md
@@ -25,14 +25,14 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - uses: actions/checkout@v4
-      - run: wasmsign2 sign --keyless -i module.wasm -o signed.wasm
+      - run: sigil sign --keyless -i module.wasm -o signed.wasm
 ```
 
 ### Command Line
 
 ```bash
 # Auto-detects OIDC provider from environment
-wasmsign2 sign --keyless -i module.wasm -o signed.wasm
+sigil sign --keyless -i module.wasm -o signed.wasm
 ```
 
 ## Signature Format
@@ -66,10 +66,10 @@ Size overhead: ~2-3KB per signature
 - Signature logged in Rekor transparency log
 - Certificate validity: ~10 minutes (enforced by Fulcio)
 
-## Verification (Coming Soon)
+## Verification
 
 ```bash
-wasmsign2 verify --keyless \
+sigil verify --keyless \
   --identity-regexp "https://github.com/owner/repo" \
   --issuer "https://token.actions.githubusercontent.com" \
   -i signed.wasm

--- a/src/cli/BUILD.bazel
+++ b/src/cli/BUILD.bazel
@@ -13,9 +13,9 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-# Version info - keep in sync with Cargo.toml
-# TODO: When version changes in Cargo.toml, update these values
-VERSION = "0.2.7"
+# Version info - keep in sync with [workspace.package].version in Cargo.toml
+# and with the `version` field in MODULE.bazel.
+VERSION = "0.8.0"
 
 rust_binary(
     name = "wasmsign_cli",

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -81,6 +81,10 @@ fn start() -> Result<(), WSError> {
         .subcommand(
             Command::new("keygen")
                 .about("Generate a new key pair")
+                .after_help(
+                    "EXAMPLES:\n    \
+                     $ sigil keygen -k secret.key -K public.key\n",
+                )
                 .arg(
                     Arg::new("secret_key")
                         .value_name("secret_key_file")
@@ -140,6 +144,11 @@ fn start() -> Result<(), WSError> {
         .subcommand(
             Command::new("sign")
                 .about("Sign a module")
+                .after_help(
+                    "EXAMPLES:\n    \
+                     $ sigil sign -k secret.key -i module.wasm -o signed.wasm\n    \
+                     $ sigil sign --keyless -i module.wasm -o signed.wasm\n",
+                )
                 .arg(
                     Arg::new("in")
                         .value_name("input_file")
@@ -205,6 +214,13 @@ fn start() -> Result<(), WSError> {
         .subcommand(
             Command::new("verify")
                 .about("Verify a module's signature")
+                .after_help(
+                    "EXAMPLES:\n    \
+                     $ sigil verify -K public.key -i signed.wasm\n    \
+                     $ sigil verify --keyless -i signed.wasm \\\n        \
+                       --cert-identity user@example.com \\\n        \
+                       --cert-oidc-issuer https://token.actions.githubusercontent.com\n",
+                )
                 .arg(
                     Arg::new("format")
                         .value_name("format")
@@ -321,7 +337,7 @@ fn start() -> Result<(), WSError> {
                 ),
         )
         .subcommand(
-            Command::new("verify_matrix")
+            Command::new("verify-matrix")
                 .about("Batch verification against multiple public keys")
                 .arg(
                     Arg::new("in")
@@ -354,6 +370,11 @@ fn start() -> Result<(), WSError> {
                 .subcommand(
                     Command::new("create")
                         .about("Create a new trust bundle")
+                        .after_help(
+                            "EXAMPLES:\n    \
+                             $ sigil bundle create -o trust.json \\\n        \
+                               --ca-cert fulcio-root.pem --rekor-key rekor.pub\n",
+                        )
                         .arg(
                             Arg::new("out")
                                 .value_name("output_file")
@@ -971,7 +992,7 @@ fn start() -> Result<(), WSError> {
         module = module.attach_signature(&detached_signature)?;
         module.serialize_to_file(output_file)?;
         println!("Signature is now embedded as a custom section.");
-    } else if let Some(matches) = matches.subcommand_matches("verify_matrix") {
+    } else if let Some(matches) = matches.subcommand_matches("verify-matrix") {
         let input_file = matches.get_one::<String>("in").map(|s| s.as_str());
         let signature_file = matches
             .get_one::<String>("signature_file")

--- a/src/lib/build.rs
+++ b/src/lib/build.rs
@@ -15,4 +15,9 @@ fn main() {
     // Set as environment variable for compile-time access
     println!("cargo::rerun-if-changed=build.rs");
     println!("cargo::rustc-env=WSC_BUILD_TIMESTAMP={}", timestamp);
+
+    // Declare the `kani` cfg used by Kani harnesses so rustc does not warn
+    // under non-Kani builds. See Kani docs:
+    // https://model-checking.github.io/kani/cargo-features.html
+    println!("cargo::rustc-check-cfg=cfg(kani)");
 }


### PR DESCRIPTION
## Summary

Closes 9 low-risk hygiene findings from the 2026-04-30 14-perspective audit
(see the 2026-04-30 audit findings for full context). Each finding is a
small, isolated change; nothing in this PR touches signing or verification
logic.

## Findings addressed

- **M-10** — `src/lib/build.rs` now declares `cargo::rustc-check-cfg=cfg(kani)`,
  silencing the `unexpected cfg condition` warning under non-Kani builds.
- **L-1** — `docs/keyless.md` and `docs/bazel-build-guide.md` no longer use
  the legacy `wasmsign2` binary name or upstream URL; the
  `module_name = "wasmsign2"` Bazel snippet now matches the canonical
  `wsc` module from `MODULE.bazel`. The "Coming Soon" verification block in
  `keyless.md` is also corrected to match README (it works today).
- **L-2** — README gains a "Quick Try (no WASM artifact required)"
  subsection that walks through build → keygen → minimal-wasm → sign → verify
  in ~10 lines. A single sentence notes that `--keyless` needs an OIDC
  provider.
- **L-5** — `sign`, `verify`, `keygen`, and `bundle create` clap subcommands
  now carry an `after_help` block with cosign-style `$ sigil ...` examples.
- **M-7** — `pulseengine/rivet/.github/actions/compliance@main` is now
  pinned to `@v0.6.0` (latest stable rivet tag) in both
  `.github/workflows/compliance.yml` and `release.yml`.
- **M-8** — `memory-profile.yml` and `tpm-tests.yml` no longer fire on
  every PR; they now run on `workflow_dispatch` plus a nightly
  `cron: '17 3 * * *'` schedule.
- **M-11** — User-visible CLI verb `verify_matrix` renamed to
  `verify-matrix` (hyphen, matching all other multi-word verbs). Internal
  Rust function names in `signature/matrix.rs` are unchanged.
- **H-8** — Crate version drift fixed. `Cargo.toml` (0.8.0) is the single
  source of truth; `MODULE.bazel` and `src/cli/BUILD.bazel` now both read
  0.8.0 with comments pointing back to `Cargo.toml`. The only remaining
  `0.2.7` in the tree is in `supply-chain/config.toml` for the third-party
  `libdbus-sys` crate (intentional).
- **H-9** — Duplicate `publish-crates` job removed from `release.yml`.
  `publish-to-crates-io.yml` is now the single tag-push publisher; its
  `if: github.repository == 'pulseengine/wsc'` guard was updated to
  `'pulseengine/sigil'` to match the renamed repository.

## Test plan

- [x] `cargo build --workspace --release` succeeds with no `cfg(kani)` warnings.
- [x] `cargo test --workspace --no-run` succeeds.
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` parses every
      modified workflow file.
- [x] `grep -ri 'wasmsign2' docs/keyless.md docs/bazel-build-guide.md`
      returns nothing.
- [x] `grep -rn '0\.2\.7' --include='*.toml' --include='*.bazel'` returns
      only the unrelated `libdbus-sys` exemption.
- [x] `grep '@main' .github/workflows/` shows no external action refs.
- [x] `grep 'cargo publish\|crates-io-auth' .github/workflows/` resolves to
      a single workflow (`publish-to-crates-io.yml`).
- [ ] Reviewer spot-checks `sigil sign --help` / `sigil verify --help` /
      `sigil keygen --help` / `sigil bundle create --help` show the new
      `EXAMPLES:` block.
- [ ] Reviewer confirms `sigil verify-matrix --help` works and that
      `sigil verify_matrix` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)