### PR TITLE
chore(ci): add concurrency control to all workflows

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,5 +1,9 @@
 name: Compliance Report
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -1,5 +1,9 @@
 name: Formal Verification
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,6 +3,10 @@
 
 name: Fuzz Testing
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 on:
   schedule:
     # Run daily at 2 AM UTC

--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -1,5 +1,9 @@
 name: Memory Profiling
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -4,6 +4,10 @@
 
 name: "Publish to crates.io"
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,5 +1,9 @@
 name: Supply Chain Security
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/tpm-tests.yml
+++ b/.github/workflows/tpm-tests.yml
@@ -1,5 +1,9 @@
 name: TPM2 Tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:  # Allow manual trigger
   schedule:

--- a/.github/workflows/wasm-signing.yml
+++ b/.github/workflows/wasm-signing.yml
@@ -12,6 +12,10 @@
 
 name: Sign WASM Module
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Per the org-wide [CI Concurrency Hardening brief](#). Adds a top-level `concurrency:` block to every workflow under `.github/workflows/`. Cancels superseded PR runs on `rust.yml` + `formal-verification.yml`; never cancels runs on `main`, tags, releases, scheduled events, or attestation-producing workflows.

**Scope:** only files under `.github/workflows/`. No job-level concurrency, no `runs-on:` changes, no caching changes, no matrix restructuring, no `permissions:` tweaks.

## Variant per workflow

| Workflow | Variant | Why |
|---|---|---|
| `rust.yml` | **default** | core CI — cancel superseded PR pushes |
| `formal-verification.yml` | **default** | Verus / Kani / Lean / Rocq matrix — multi-hour, exactly the saving target |
| `release.yml` | **release** | `release-${{ github.ref }}`; never cancel |
| `publish-to-crates-io.yml` | **release** | `release-${{ github.ref }}`; never cancel |
| `compliance.yml` | **compliance** | filename signal |
| `supply-chain.yml` | **compliance** | Cargo Audit / Deny / Vet — must complete on main |
| `wasm-signing.yml` | **compliance** | filename "sign" — produces signed attestations |
| `fuzz.yml` | **scheduled** | nightly cargo-fuzz @ 02:00 UTC |
| `memory-profile.yml` | **scheduled** | nightly ByteHound @ 03:17 UTC |
| `tpm-tests.yml` | **scheduled** | nightly swtpm @ 03:17 UTC |

## Notes on classification

- **`supply-chain.yml` is not literally named compliance/audit/sbom** but its content is exactly that. Upgrading to the compliance variant so security scans always complete on main; the brief's "when in doubt, default" applies to ambiguous cases — this one is unambiguous on inspection.
- **`fuzz.yml` / `memory-profile.yml` / `tpm-tests.yml` have `schedule:` + `workflow_dispatch:`** rather than `schedule:` as the only trigger. Using the **scheduled** variant anyway because the semantic intent matches: each run is independent data-collection that must not be queued or cancelled by another scheduled or manual fire. Using `default` would have produced the same effective behaviour today (no PR triggers means `cancel-in-progress` evaluates to `false`), but the `${{ github.run_id }}` group is more honest about the intent.

## Verification

- [x] All 10 workflow files now have a top-level `concurrency:` block (no job-level blocks).
- [x] YAML parses cleanly under `python3 -c "import yaml; yaml.safe_load(open(F))"` for each file.
- [ ] CI on this PR must pass.
- [ ] After merge, the post-merge `main` run of each workflow must complete normally (not be cancelled by its own `concurrency` block firing on the merge commit). The `cancel-in-progress` is conditional on `pull_request`; pushes to main fall through.

## Out of scope

- Self-hosted runner migration
- Job parallelization / matrix restructuring
- Cache strategy changes
- Permission minimization

These depend on this PR landing first.