### PR TITLE
ci: migrate 12 of 26 jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -37,6 +37,7 @@ on:
 jobs:
   compliance:
     name: Generate compliance report
+    # Stays on ubuntu-latest: uses pulseengine/rivet/.github/actions/compliance composite action whose internals (likely docker compose / pandoc / weasyprint) are not yet validated against smithy's hardened runner.
     runs-on: ubuntu-latest
     outputs:
       archive-path: ${{ steps.report.outputs.archive-path }}

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   verus-proofs:
     name: Verus SMT Verification
+    # Stays on ubuntu-latest: uses bazel-contrib/setup-bazel; Bazel is not installed on smithy (tracked as out-of-scope in migration playbook).
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -55,6 +56,7 @@ jobs:
 
   kani-proofs:
     name: Kani ${{ matrix.module }}
+    # Stays on ubuntu-latest: kani-verifier bundles CBMC (~100 MB) which is not in smithy's toolchains role (tracked as out-of-scope in migration playbook).
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -98,6 +100,7 @@ jobs:
 
   rocq-proofs:
     name: Rocq/coq-of-rust Translation
+    # Stays on ubuntu-latest: uses cachix/install-nix-action + bazel-contrib/setup-bazel + Rocq/Coq toolchain; none of Nix, Bazel, or Rocq are installed on smithy (all tracked as out-of-scope in migration playbook).
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, lean-mem]
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +75,7 @@ jobs:
   report:
     name: Fuzz Report
     needs: fuzz
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     if: always()
 
     steps:

--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   bytehound-profile:
     name: ByteHound Memory Profile
+    # Stays on ubuntu-latest: installs build deps via sudo apt-get (build-essential, gcc, jq); smithy's runner user has no sudo.
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'pulseengine/sigil'
+    # Stays on ubuntu-latest: crates.io trusted publishing via OIDC; keep release publication on a vetted, well-known runner image until self-hosted publication path is independently audited.
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
   # Generate compliance report from rivet artifacts
   build-compliance:
     name: Build compliance report
+    # Stays on ubuntu-latest: uses pulseengine/rivet/.github/actions/compliance composite action whose internals are not yet validated against smithy's hardened runner.
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -47,6 +48,7 @@ jobs:
   # Build native CLI binaries for all platforms
   build-native-cli:
     name: Build CLI (${{ matrix.target }})
+    # Stays on ubuntu-latest / macos / windows: matrix spans macOS + Windows (smithy is Linux-only) and Linux entries use sudo apt-get for cross-compilation toolchains and libtss2-dev.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -139,6 +141,7 @@ jobs:
 
   build-and-release:
     name: Build & Release WASM Component
+    # Stays on ubuntu-latest: uses sudo apt-get for build-essential, plus cachix/install-nix-action and bazel-contrib/setup-bazel; smithy has no sudo and no Nix or Bazel.
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   build-matrix:
     name: ${{ matrix.build-system }} on ${{ matrix.os }}
+    # Stays on ubuntu-latest: matrix includes macos-latest and bazel build-system uses cachix/install-nix-action; smithy is Linux-only and doesn't ship Nix or Bazel.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -149,7 +150,7 @@ jobs:
   # Integration tests for keyless signing (requires OIDC)
   keyless-integration:
     name: Keyless Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       id-token: write  # Required for OIDC token
       contents: read
@@ -165,7 +166,7 @@ jobs:
   # Air-gapped verification end-to-end tests
   airgapped-e2e:
     name: Air-Gapped E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       id-token: write  # Required for OIDC token
       contents: read
@@ -186,7 +187,7 @@ jobs:
   # Example: Sign a WASM module and verify with air-gapped flow
   sign-and-verify-example:
     name: Sign & Verify Example
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       id-token: write
       contents: read
@@ -253,7 +254,7 @@ jobs:
   # Rekor verification tests with fresh data
   rekor-verification:
     name: Rekor Verification Tests (Fresh Data)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -284,7 +285,7 @@ jobs:
   coverage:
     name: Code Coverage
     needs: [build-matrix]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   cargo-vet:
     name: Cargo Vet
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
@@ -38,6 +38,7 @@ jobs:
 
   cargo-audit:
     name: Cargo Audit
+    # Stays on ubuntu-latest: smithy-shipped cargo-audit's bundled rustsec parser rejects RUSTSEC-2026-0037 ("unsupported CVSS version: 4.0"). Move back once smithy bumps cargo-audit to 0.22.1+.
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -59,14 +60,20 @@ jobs:
 
   cargo-deny:
     name: Cargo Deny
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v2
+    - uses: dtolnay/rust-toolchain@stable
+    # EmbarkStudios/cargo-deny-action@v2 launches a rootless container which
+    # fails on smithy (newuidmap is setuid + NoNewPrivileges=true on the
+    # runner unit). Direct install + invocation, per smithy migration playbook.
+    # bans/licenses/sources only (advisories handled by cargo-audit job).
+    - run: cargo install cargo-deny --locked --version 0.16.4 || true
+    - run: cargo deny check bans licenses sources
 
   mutants:
     name: Mutation Testing
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/tpm-tests.yml
+++ b/.github/workflows/tpm-tests.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   tpm2-tests:
     name: TPM2 Tests with swtpm
+    # Stays on ubuntu-latest: installs swtpm/swtpm-tools/libtss2-dev/tpm2-tools via sudo apt-get; smithy's runner user has no sudo.
     runs-on: ubuntu-latest
 
     steps:
@@ -111,6 +112,7 @@ jobs:
   # Verify the feature compiles on macOS (but doesn't run tests)
   tpm2-macos-compile:
     name: TPM2 Compile Check (macOS)
+    # Stays on macos-latest: smithy is Linux x86_64 only.
     runs-on: macos-latest
 
     steps:
@@ -136,6 +138,7 @@ jobs:
   #       simply doesn't include the TPM module (platform guards exclude it).
   tpm2-windows-compile:
     name: TPM2 Compile Check (Windows)
+    # Stays on windows-latest: smithy is Linux x86_64 only.
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/wasm-signing.yml
+++ b/.github/workflows/wasm-signing.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   sign-wasm:
     name: Sign WASM Module
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       id-token: write   # Required for Sigstore OIDC
       contents: read
@@ -88,7 +88,7 @@ jobs:
   # Optional: Generate trust bundle for air-gapped devices
   generate-trust-bundle:
     name: Generate Trust Bundle
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     if: github.event_name == 'release'
 
     steps:


### PR DESCRIPTION
## Summary

Broad migration of sigil CI to the pulseengine smithy self-hosted runner fleet, mirroring the pattern proven on spar (#201), rivet (#262), kiln (#247), and gale (#35). Twelve of twenty-six jobs across nine workflows move to smithy; the rest stay on hosted with an in-place comment naming the reason. Edits are minimal — only `runs-on:` lines and one documented workaround (cargo-deny).

## Migrated -> smithy

| Class | Job(s) |
|---|---|
| `[self-hosted, linux, x64, rust-cpu]` | rust.yml: `keyless-integration`, `airgapped-e2e`, `sign-and-verify-example`, `rekor-verification`, `coverage`; supply-chain.yml: `cargo-deny`; wasm-signing.yml: `sign-wasm`, `generate-trust-bundle` |
| `[self-hosted, linux, x64, lean-mem]` | supply-chain.yml: `mutants`; fuzz.yml: `fuzz` (matrix x6) |
| `[self-hosted, linux, x64, light]` | supply-chain.yml: `cargo-vet`; fuzz.yml: `report` |

Memory-aggressive workloads (cargo-mutants, cargo-fuzz) target `lean-mem` (24 G ceiling). Pure no-compile tasks (cargo vet, artefact summarisation) take `light` (4 G). Everything else compile-bound goes to `rust-cpu` (12 G).

## Stays on hosted (in-place reasons retained in each file)

| Job | File | Why hosted |
|---|---|---|
| `compliance` | compliance.yml | Uses `pulseengine/rivet/.github/actions/compliance` composite action; internals (likely docker compose / pandoc / weasyprint) not yet validated against smithy |
| `build-compliance` | release.yml | Same rivet compliance composite action |
| `verus-proofs` | formal-verification.yml | `bazel-contrib/setup-bazel`; Bazel not in smithy toolchains role |
| `kani-proofs` | formal-verification.yml | `kani-verifier` bundles CBMC (~100 MB); not on smithy |
| `rocq-proofs` | formal-verification.yml | Nix + Bazel + Rocq; none on smithy |
| `bytehound-profile` | memory-profile.yml | `sudo apt-get install build-essential gcc jq` |
| `publish` | publish-to-crates-io.yml | crates.io trusted publishing via OIDC; keep release publication on a vetted image |
| `build-native-cli` | release.yml | Matrix spans macOS + Windows; Linux entries `sudo apt-get` for cross-toolchain and libtss2-dev |
| `build-and-release` | release.yml | `sudo apt-get` + Nix + Bazel |
| `build-matrix` | rust.yml | Matrix `[ubuntu, macos] x [cargo, bazel]`; macOS plus Nix-via-Bazel needed |
| `cargo-audit` | supply-chain.yml | Smithy-shipped cargo-audit's bundled rustsec parser rejects RUSTSEC-2026-0037 ("unsupported CVSS version: 4.0"); flips back once smithy bumps to 0.22.1+ |
| `tpm2-tests` | tpm-tests.yml | `sudo apt-get install swtpm swtpm-tools libtss2-dev tpm2-tools` |
| `tpm2-macos-compile` | tpm-tests.yml | macOS only |
| `tpm2-windows-compile` | tpm-tests.yml | Windows only |

## Workarounds applied

- **`cargo-deny`** — `EmbarkStudios/cargo-deny-action@v2` launches a rootless container that fails on smithy (setuid `newuidmap` + `NoNewPrivileges=true` on the runner unit). Replaced per playbook with a direct toolchain install + `cargo install cargo-deny --locked --version 0.16.4 || true` + `cargo deny check bans licenses sources`. Advisories deliberately skipped — they remain covered by the `cargo-audit` job that stays on hosted, until the smithy-pinned `cargo-audit` is bumped to 0.22.1+ (also tracked in playbook).

No other workarounds were needed — none of the migrated jobs use `sudo mv ... /usr/local/bin`, `obi1kenobi/cargo-semver-checks-action`, or `rustsec/audit-check`.

## Test plan

- [ ] Twelve migrated jobs land on `rust-cpu` / `lean-mem` / `light` runners and finish green
- [ ] `cargo-deny` check produces the same bans/licenses/sources verdict as the previous Embark wrapper
- [ ] `mutants` and `fuzz` complete inside the 24 G `lean-mem` ceiling with no OOMs
- [ ] Fourteen hosted jobs remain unchanged in behaviour
- [ ] No EACCES events appear in smithy's `journalctl -u smithy-trace-eacces.service`
- [ ] No "no space left on device" — TMPDIR fix on lv_runners (500 G) absorbs cargo-fuzz corpus growth

## Rollback

Revert this commit; all twelve jobs flip back to `ubuntu-latest` and the cargo-deny step reverts to `EmbarkStudios/cargo-deny-action@v2`.