### PR TITLE
fix(ci): harden cargo-deny step (post-#106 cleanup)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -64,12 +64,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    # EmbarkStudios/cargo-deny-action@v2 launches a rootless container which
-    # fails on smithy (newuidmap is setuid + NoNewPrivileges=true on the
-    # runner unit). Direct install + invocation, per smithy migration playbook.
-    # bans/licenses/sources only (advisories handled by cargo-audit job).
-    - run: cargo install cargo-deny --locked --version 0.16.4 || true
-    - run: cargo deny check bans licenses sources
+    # EmbarkStudios/cargo-deny-action@v2 runs in a musl container that can't
+    # install the toolchain pinned by rust-toolchain.toml (issue #103). Also
+    # fails on smithy (rootless container + NoNewPrivileges). Install +
+    # invoke cargo-deny directly so the runner's rustup respects the project
+    # toolchain file. bans/licenses/sources only — advisories live in the
+    # cargo-audit job above.
+    - name: Install cargo-deny
+      run: cargo install --locked cargo-deny --version 0.16.4
+    - name: Run cargo deny check
+      run: cargo deny check bans licenses sources
 
   mutants:
     name: Mutation Testing


### PR DESCRIPTION
Cleans up two residual defects in the \`Cargo Deny\` step that PR #106 (smithy runner migration) replaced. **Closes #103.**

## Context

Issue #103 reported that \`Cargo Deny\` was failing because \`EmbarkStudios/cargo-deny-action@v2\` ran in a musl container that couldn't install the toolchain pinned by \`rust-toolchain.toml\`. PR #106 already replaced the action with a direct rustup + \`cargo install --locked\` + \`cargo deny check\` flow on a regular runner. So the original symptom is gone.

But two minor defects remained in that direct flow:

1. \`cargo install --locked cargo-deny --version 0.16.4 || true\` — the \`|| true\` swallows install failures, then the next step fails with a confusing "command not found". Removed.
2. The install/check steps had no explicit \`name:\` label, so logs were harder to read. Added.
3. The rationale comment didn't reference \`rust-toolchain.toml\` (the actual root cause). Updated.

## Out of scope (follow-up)

The agent who reviewed this flagged that \`thiserror\` 1.x and 2.x are duplicated in the dep graph. cargo-deny will likely flag this on the first clean run after this lands. If so, that's a separate, smaller PR.

## Test plan

- [x] yaml parses cleanly
- [ ] CI's Cargo Deny step runs to completion (either green or with a real, useful error message)

Closes #103.