### PR TITLE
verify: discharge lemma_le64_injective

### DIFF
--- a/src/lib/src/verus_proofs/dsse_proofs.rs
+++ b/src/lib/src/verus_proofs/dsse_proofs.rs
@@ -43,28 +43,106 @@ pub open spec fn spec_pae(
 
 // ── LE64 injectivity ────────────────────────────────────────────────
 
-/// **SPECIFICATION ONLY** — proof obligation not yet discharged.
-/// See `audit/2026-04-30/findings.md` C-1.
+/// LEMMA (CV-22 supporting): little-endian u64 encoding is injective.
 ///
-/// LEMMA (intended): le64 encoding is injective.
-///
-/// To actually discharge: case-split on `a != b` to obtain a bit position
-/// where the two u64s differ; show that bit lives in one of the eight
-/// `spec_le64` byte slots; conclude the corresponding byte differs, so
-/// the resulting `Seq<u8>` differs by `Seq` extensionality. Requires
-/// Verus' bit-vector mode (`assert(...) by(bit_vector)`) plus a `Seq`
-/// extensionality lemma from `vstd`.
+/// Proof approach: contrapositive via byte-wise equality.
+///   1. If the two `Seq<u8>` outputs are equal, all eight indexed bytes
+///      are equal. Indexing `seq![x0..x7][i]` reduces to `xi` directly
+///      from the macro expansion, so each `sa[i] == sb[i]` exposes the
+///      corresponding `(a >> 8*i) & 0xFF` slice.
+///   2. A single `assert(...) by(bit_vector)` call discharges that the
+///      eight byte-slice equalities together imply `a == b`. This is a
+///      pure bit-vector tautology that Verus' bit-vector solver decides
+///      directly — every bit of `a` and `b` is captured by exactly one
+///      of the eight `0xFF`-masked shifts.
+///   3. Combining (1) and (2) under the assumption `sa == sb` yields
+///      `a == b`, contradicting the `requires a != b` precondition.
 pub proof fn lemma_le64_injective(a: u64, b: u64)
     requires a != b,
     ensures spec_le64(a) != spec_le64(b),
 {
-    // Z3 can reason about bitvector operations directly.
-    // The LE64 encoding preserves all bits, so different inputs
-    // produce different byte sequences.
-    // NOTE: Z3 needs help with Seq inequality — use assume for now.
-    // The property is trivially true by construction of spec_le64.
-    // ADMITTED — see SPECIFICATION ONLY block above. Audit C-1 (2026-04-30).
-    assume(false);
+    let sa = spec_le64(a);
+    let sb = spec_le64(b);
+
+    // Step 1: Bit-vector tautology — if all eight LE byte-slice equalities
+    // hold simultaneously, the u64s themselves are equal. Phrased as a
+    // closed quantifier-free goal in (a, b) so the bit-vector solver
+    // decides it directly. Slices stay as u64 (`0xFF` mask) rather than
+    // `as u8` so the bv backend reasons in a single sort.
+    assert(
+        (
+            (a & 0xFF) == (b & 0xFF)
+            && ((a >> 8) & 0xFF) == ((b >> 8) & 0xFF)
+            && ((a >> 16) & 0xFF) == ((b >> 16) & 0xFF)
+            && ((a >> 24) & 0xFF) == ((b >> 24) & 0xFF)
+            && ((a >> 32) & 0xFF) == ((b >> 32) & 0xFF)
+            && ((a >> 40) & 0xFF) == ((b >> 40) & 0xFF)
+            && ((a >> 48) & 0xFF) == ((b >> 48) & 0xFF)
+            && ((a >> 56) & 0xFF) == ((b >> 56) & 0xFF)
+        ) ==> a == b
+    ) by (bit_vector);
+
+    // Step 2: Bit-vector bridge — `(x & 0xFF) as u8 == (y & 0xFF) as u8`
+    // is equivalent to `(x & 0xFF) == (y & 0xFF)` because the masked
+    // value already fits in u8, so the truncating cast is value-preserving.
+    // Eight concrete instantiations so no triggers are needed.
+    assert((a & 0xFF) as u8 == (b & 0xFF) as u8
+        <==> (a & 0xFF) == (b & 0xFF)) by (bit_vector);
+    assert(((a >> 8) & 0xFF) as u8 == ((b >> 8) & 0xFF) as u8
+        <==> ((a >> 8) & 0xFF) == ((b >> 8) & 0xFF)) by (bit_vector);
+    assert(((a >> 16) & 0xFF) as u8 == ((b >> 16) & 0xFF) as u8
+        <==> ((a >> 16) & 0xFF) == ((b >> 16) & 0xFF)) by (bit_vector);
+    assert(((a >> 24) & 0xFF) as u8 == ((b >> 24) & 0xFF) as u8
+        <==> ((a >> 24) & 0xFF) == ((b >> 24) & 0xFF)) by (bit_vector);
+    assert(((a >> 32) & 0xFF) as u8 == ((b >> 32) & 0xFF) as u8
+        <==> ((a >> 32) & 0xFF) == ((b >> 32) & 0xFF)) by (bit_vector);
+    assert(((a >> 40) & 0xFF) as u8 == ((b >> 40) & 0xFF) as u8
+        <==> ((a >> 40) & 0xFF) == ((b >> 40) & 0xFF)) by (bit_vector);
+    assert(((a >> 48) & 0xFF) as u8 == ((b >> 48) & 0xFF) as u8
+        <==> ((a >> 48) & 0xFF) == ((b >> 48) & 0xFF)) by (bit_vector);
+    assert(((a >> 56) & 0xFF) as u8 == ((b >> 56) & 0xFF) as u8
+        <==> ((a >> 56) & 0xFF) == ((b >> 56) & 0xFF)) by (bit_vector);
+
+    // Step 3: Unfold spec_le64 at every index so each byte of the encoding
+    // is visible to the SMT solver as the exact masked-shift slice. These
+    // identities hold unconditionally (by the macro/spec definition of
+    // `spec_le64`), not as a claim about the two encodings agreeing.
+    assert(sa[0] == (a & 0xFF) as u8);
+    assert(sa[1] == ((a >> 8) & 0xFF) as u8);
+    assert(sa[2] == ((a >> 16) & 0xFF) as u8);
+    assert(sa[3] == ((a >> 24) & 0xFF) as u8);
+    assert(sa[4] == ((a >> 32) & 0xFF) as u8);
+    assert(sa[5] == ((a >> 40) & 0xFF) as u8);
+    assert(sa[6] == ((a >> 48) & 0xFF) as u8);
+    assert(sa[7] == ((a >> 56) & 0xFF) as u8);
+    assert(sb[0] == (b & 0xFF) as u8);
+    assert(sb[1] == ((b >> 8) & 0xFF) as u8);
+    assert(sb[2] == ((b >> 16) & 0xFF) as u8);
+    assert(sb[3] == ((b >> 24) & 0xFF) as u8);
+    assert(sb[4] == ((b >> 32) & 0xFF) as u8);
+    assert(sb[5] == ((b >> 40) & 0xFF) as u8);
+    assert(sb[6] == ((b >> 48) & 0xFF) as u8);
+    assert(sb[7] == ((b >> 56) & 0xFF) as u8);
+    assert(sa.len() == 8);
+    assert(sb.len() == 8);
+
+    // Step 4: Explicit contradiction in the equal-encoding case. Verus
+    // takes the conditional as a hint to specialise reasoning to the
+    // `sa == sb` branch, where congruence over `==` gives byte equalities
+    // that, via the bridges (Step 2) and the bit-vector tautology (Step 1),
+    // force `a == b` — contradicting `requires a != b`. Outside the
+    // branch, the goal `sa != sb` follows trivially.
+    if sa == sb {
+        assert(sa[0] == sb[0]);
+        assert(sa[1] == sb[1]);
+        assert(sa[2] == sb[2]);
+        assert(sa[3] == sb[3]);
+        assert(sa[4] == sb[4]);
+        assert(sa[5] == sb[5]);
+        assert(sa[6] == sb[6]);
+        assert(sa[7] == sb[7]);
+        assert(a == b);
+    }
 }
 
 // ── PAE injectivity ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the `assume(false)` in `lemma_le64_injective` (`src/lib/src/verus_proofs/dsse_proofs.rs`) with an explicit four-step proof. Discharges one of the relabeled `SPECIFICATION ONLY` theorems from audit C-1; the remaining admits in `dsse_proofs.rs` and `merkle_proofs.rs` are unchanged.

## Proof technique

1. **Bit-vector tautology (Step 1).** A single `assert(...) by(bit_vector)` proves the closed quantifier-free goal: if the eight `0xFF`-masked shifts of `a` agree with the corresponding shifts of `b`, then `a == b`. This is a pure tautology in `BitVec64` — every bit of `a` and `b` lives in exactly one byte-slice.

2. **u8 <-> u64 bridge (Step 2).** Eight concrete `<==>` asserts (also `by(bit_vector)`) lift each `(x & 0xFF) as u8 == (y & 0xFF) as u8` to `(x & 0xFF) == (y & 0xFF)`. The truncating cast is value-preserving because the mask already truncates to `[0, 0xFF]`. Concrete instantiations avoid trigger headaches.

3. **`spec_le64` unfolding (Step 3).** Sixteen unfolding asserts expose `spec_le64(x)[i] == (x >> 8*i) & 0xFF as u8` for each `i in 0..8`. These are pure macro/spec identities; they hold unconditionally.

4. **Conditional contradiction (Step 4).** Under `sa == sb`, congruence on `==` gives the eight byte equalities `sa[i] == sb[i]`. The bridges (Step 2) lift those to u64 mask equalities; the bv tautology (Step 1) forces `a == b`, contradicting `requires a != b`. Outside the branch, `sa != sb` is the goal directly.

## Why this should work

- `spec_le64` is `pub open spec fn`, so Verus sees through it.
- `seq![x0..x7][i]` reduces to `xi` by the `seq!` macro expansion.
- Z3's bit-vector backend (via `by(bit_vector)`) reliably decides the closed Step-1 goal; it is small (eight 8-bit slices of a 64-bit value).
- The `if sa == sb { ... assert(a == b); }` pattern is the standard Verus idiom for proof-by-contradiction over an equality goal.

## Honesty notes

- Could not run `bazel build //src/lib/src/verus_proofs:wsc_merkle_proofs` locally — Bazel toolchain download failed (`no space left on device`). The proof must be validated by CI.
- The Verus job in `.github/workflows/formal-verification.yml` still has `continue-on-error: true` per the partial-closure plan (per the task brief, the CI mask should stay until more admits are discharged). So this PR's CI will not block on the Verus job, but the bazel build logs will reveal whether the proof actually verified.
- If CI reports the proof did not discharge, the next iteration starts by inspecting which `assert(...)` Verus rejected — the Step-1 bv assert is the most likely friction point (slicing reasoning vs Z3's bv decision procedure performance), with a fallback being eight per-byte bv asserts joined explicitly.

## Test plan

- [ ] `cargo build --workspace --release` clean (verified locally — Verus annotations are inert outside Bazel).
- [ ] `bazel build //src/lib/src/verus_proofs:wsc_merkle_proofs` reports `verification successful` for `lemma_le64_injective`. Other admits in the file remain `assume(false)` so the file as a whole still verifies (because `assume(false)` makes the obligation vacuous).
- [ ] CI's Verus job log (under `continue-on-error: true`) shows one fewer admitted lemma.

## Scope

- Only `src/lib/src/verus_proofs/dsse_proofs.rs` is touched.
- `formal-verification.yml` is intentionally left alone — CI mask removal is a follow-up after more admits land.

Refs: audit C-1
Verifies: CR-3 (parser injectivity property of PAE encoding)

Generated with [Claude Code](https://claude.com/claude-code)
