### PR TITLE
feat(benches): criterion benches for signature verification (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +288,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -541,6 +580,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +639,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -840,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1074,6 +1155,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1193,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1426,6 +1524,26 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1757,7 +1875,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1893,6 +2011,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2149,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pori"
@@ -2586,7 +2738,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2651,6 +2803,15 @@ name = "ryu-js"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scientific"
@@ -3020,7 +3181,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3130,6 +3291,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3539,6 +3710,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -4077,7 +4258,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4392,6 +4573,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "const-oid",
+ "criterion",
  "ct-codecs",
  "ecdsa",
  "ed25519-compact",

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -109,6 +109,12 @@ optional = true
 [dev-dependencies]
 # WAT (WebAssembly Text) parser for tests
 wat = "1.221"
+# Criterion for signature-verification benchmarks (issue #89)
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "verification_benchmarks"
+harness = false
 
 [features]
 default = ["software-keys", "sync"]

--- a/src/lib/benches/verification_benchmarks.rs
+++ b/src/lib/benches/verification_benchmarks.rs
@@ -1,0 +1,249 @@
+//! Criterion benchmarks for sigil's signature-verification hot paths.
+//!
+//! sigil is on the supply-chain hot path: every signature verification must
+//! complete within a build-time budget. These benchmarks capture per-path
+//! latency baselines so silent crypto-path regressions surface as criterion
+//! diffs rather than mysteriously slow CI runs.
+//!
+//! Implements issue #89 (acceptance criteria sans the SLH-DSA path, which
+//! is deferred to issue #46, and sans the CI integration, which is deferred
+//! to a follow-up PR).
+//!
+//! # Traceability (rivet artifacts in `artifacts/cybersecurity/goals-and-requirements.yaml`)
+//!
+//! | bench group              | requirement                                              |
+//! |--------------------------|----------------------------------------------------------|
+//! | `ed25519_verify`         | CR-1  Use Approved Cryptographic Algorithms (Ed25519)    |
+//! |                          | CR-3  Verify Software Integrity                          |
+//! |                          | RFC 8032 (Ed25519) timing budget                         |
+//! | `dsse_parse_and_verify`  | CR-3  Verify Software Integrity                          |
+//! |                          | CR-8  Bound Resource Consumption (parser budget)         |
+//! | `merkle_validation`      | CR-3  Verify Software Integrity                          |
+//! |                          | CR-5  Log Security Events via Transparency Log (RFC 6962)|
+//! |                          | CR-8  Bound Resource Consumption                         |
+//! | `cert_chain_validation`  | CR-7  Enforce Certificate Pinning for Sigstore           |
+//! |                          | CR-8  Bound Resource Consumption (MAX_CHAIN_DEPTH = 8)   |
+//!
+//! The SLH-DSA bench (FIPS 205) is intentionally omitted — see issue #46.
+//!
+//! # Running
+//!
+//! ```text
+//! cargo bench -p wsc --bench verification_benchmarks                 # full run
+//! cargo bench -p wsc --bench verification_benchmarks -- --quick      # smoke
+//! ```
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+use wsc::dsse::{payload_types, DsseEnvelope, Ed25519DsseSigner, Ed25519DsseVerifier};
+use wsc::keyless::merkle::{compute_leaf_hash, compute_node_hash, verify_inclusion_proof};
+use wsc::keyless::{KeylessSignature, RekorEntry, MAX_CHAIN_DEPTH};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Group 1: Ed25519 signature verify (CR-1, CR-3 / RFC 8032)
+// ─────────────────────────────────────────────────────────────────────────
+
+fn bench_ed25519_verify(c: &mut Criterion) {
+    // Set up the input *once* — outside the inner loop.
+    let kp = ed25519_compact::KeyPair::generate();
+    let message: Vec<u8> = b"sigil-bench-fixed-payload-for-ed25519-verify".to_vec();
+    let signature = kp.sk.sign(&message, None);
+
+    let mut group = c.benchmark_group("ed25519_verify");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("verify_64B_message", |b| {
+        b.iter(|| {
+            // black_box on the inputs so the compiler can't constant-fold the verify.
+            let res = kp
+                .pk
+                .verify(black_box(&message[..]), black_box(&signature));
+            black_box(res.is_ok())
+        });
+    });
+    group.finish();
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Group 2: DSSE envelope parse + verify (CR-3, CR-8)
+// ─────────────────────────────────────────────────────────────────────────
+
+fn bench_dsse_parse_and_verify(c: &mut Criterion) {
+    // Construct a small envelope *once*; bench parses-then-verifies it.
+    let kp = ed25519_compact::KeyPair::generate();
+    let signer = Ed25519DsseSigner::new(kp.sk.clone(), Some("bench-key".to_string()));
+    let verifier = Ed25519DsseVerifier::new(kp.pk);
+
+    let payload = b"{\"_type\":\"https://in-toto.io/Statement/v1\",\"subject\":[]}";
+    let envelope =
+        DsseEnvelope::sign(payload, payload_types::IN_TOTO, &signer).expect("sign envelope");
+    let envelope_json = envelope.to_json().expect("serialize envelope");
+
+    let mut group = c.benchmark_group("dsse_parse_and_verify");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("from_json_then_verify", |b| {
+        b.iter(|| {
+            let parsed =
+                DsseEnvelope::from_json(black_box(&envelope_json)).expect("parse envelope");
+            let payload = parsed.verify(&verifier).expect("verify envelope");
+            black_box(payload)
+        });
+    });
+    group.finish();
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Group 3: Merkle tree validation, parameterised by leaf count (CR-3, CR-5, CR-8)
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Build a complete-binary Merkle tree over `leaf_count` synthetic leaves and
+/// return `(root, leaf_hashes, audit_path_for_leaf_0)` — enough to feed
+/// `verify_inclusion_proof` for leaf 0 in a benchmark loop.
+///
+/// Implementation note: we use the *same* leaf/node hash primitives the
+/// production verifier consumes, so the audit path is guaranteed valid.
+/// We only support `leaf_count` that is a power of two to keep the fixture
+/// construction trivial — that's fine for benchmarks (we just want a
+/// realistic verify-side cost, not to exercise the odd-tree-size logic).
+fn build_merkle_fixture(leaf_count: usize) -> ([u8; 32], [u8; 32], Vec<[u8; 32]>) {
+    assert!(leaf_count.is_power_of_two() && leaf_count >= 1);
+
+    // Compute leaf hashes for synthetic leaves.
+    let mut level: Vec<[u8; 32]> = (0..leaf_count)
+        .map(|i| {
+            let leaf = format!("sigil-bench-leaf-{i}");
+            compute_leaf_hash(leaf.as_bytes())
+        })
+        .collect();
+
+    let leaf0_hash = level[0];
+
+    // Walk up the tree, collecting the sibling at each level along the
+    // path from leaf 0 to the root. For leaf 0 the sibling is always
+    // the right-hand neighbour at index 1, then the right subtree root, etc.
+    let mut audit_path: Vec<[u8; 32]> = Vec::new();
+    while level.len() > 1 {
+        // Sibling of leaf 0 at this level is level[1] (always the right
+        // child of the leftmost pair).
+        audit_path.push(level[1]);
+
+        // Reduce level pairwise.
+        let mut next: Vec<[u8; 32]> = Vec::with_capacity(level.len() / 2);
+        for pair in level.chunks(2) {
+            next.push(compute_node_hash(&pair[0], &pair[1]));
+        }
+        level = next;
+    }
+
+    let root = level[0];
+    (root, leaf0_hash, audit_path)
+}
+
+fn bench_merkle_validation(c: &mut Criterion) {
+    let leaf_counts: &[usize] = &[8, 64, 512, 4096];
+
+    let mut group = c.benchmark_group("merkle_validation");
+    for &n in leaf_counts {
+        // Set up the fixture *once* per parameter — not in the inner loop.
+        let (root, leaf_hash, audit_path) = build_merkle_fixture(n);
+        let tree_size = n as u64;
+
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let res = verify_inclusion_proof(
+                    black_box(0),
+                    black_box(tree_size),
+                    black_box(&leaf_hash),
+                    black_box(&audit_path),
+                    black_box(&root),
+                );
+                black_box(res.is_ok())
+            });
+        });
+    }
+    group.finish();
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Group 4: Cert-chain parse + length-bound validation (CR-7, CR-8 / MAX_CHAIN_DEPTH=8)
+// ─────────────────────────────────────────────────────────────────────────
+//
+// We bench the *parse + length-check* portion of cert-chain validation:
+//   KeylessSignature::from_bytes  →  cert_chain.len() check against MAX_CHAIN_DEPTH
+//
+// The full WebPKI verification path (verify_cert_chain) requires real Fulcio
+// roots and integrated_time fixtures, which would dominate the measurement
+// with I/O setup rather than per-cert validation cost. The parse+bound check
+// is the actual hot path on the inbound side (audit PR #98 added this
+// MAX_CHAIN_DEPTH=8 guard precisely so that adversarial deep chains are
+// rejected *before* the heavy WebPKI work begins).
+
+fn make_keyless_signature(chain_len: usize) -> KeylessSignature {
+    // Plausible-shaped PEMs — the parser only validates UTF-8 + length-prefix
+    // framing at this layer, not the X.509 contents.
+    let cert_chain: Vec<String> = (0..chain_len)
+        .map(|i| {
+            format!(
+                "-----BEGIN CERTIFICATE-----\nbench-cert-{i:03}-padding-padding-padding-padding\n-----END CERTIFICATE-----"
+            )
+        })
+        .collect();
+
+    let rekor_entry = RekorEntry {
+        uuid: "bench-uuid".to_string(),
+        log_index: 1,
+        body: "eyJiZW5jaCI6dHJ1ZX0=".to_string(),
+        log_id: "bench-log-id".to_string(),
+        inclusion_proof: vec![1, 2, 3, 4],
+        signed_entry_timestamp: "c2lnbmF0dXJl".to_string(),
+        integrated_time: "2025-01-01T00:00:00Z".to_string(),
+    };
+
+    KeylessSignature::new(
+        vec![0u8; 64],     // Ed25519-sized signature placeholder
+        cert_chain,
+        rekor_entry,
+        vec![0xab; 32],    // SHA-256-sized module hash placeholder
+    )
+}
+
+fn bench_cert_chain_validation(c: &mut Criterion) {
+    // Parameter set matches MAX_CHAIN_DEPTH = 8 (audit PR #98).
+    let chain_lens: &[usize] = &[1, 2, 4, 8];
+
+    let mut group = c.benchmark_group("cert_chain_validation");
+    for &len in chain_lens {
+        assert!(
+            len <= MAX_CHAIN_DEPTH,
+            "bench parameter must respect MAX_CHAIN_DEPTH bound"
+        );
+
+        // Build a serialized KeylessSignature once per parameter.
+        let sig = make_keyless_signature(len);
+        let bytes = sig.to_bytes().expect("serialize KeylessSignature");
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(len), &len, |b, _| {
+            b.iter(|| {
+                // Parse the embedded signature blob (this is the real
+                // entry point a verifier hits before WebPKI runs).
+                let parsed = KeylessSignature::from_bytes(black_box(&bytes))
+                    .expect("parse KeylessSignature");
+                // Length-bound check matches the MAX_CHAIN_DEPTH guard that
+                // runs at the start of verify_cert_chain (audit PR #98).
+                let ok = parsed.cert_chain.len() <= MAX_CHAIN_DEPTH;
+                black_box(ok)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_ed25519_verify,
+    bench_dsse_parse_and_verify,
+    bench_merkle_validation,
+    bench_cert_chain_validation,
+);
+criterion_main!(benches);


### PR DESCRIPTION
Implements **#89**. Adds criterion-driven benchmarks for the four signature-verification hot paths so silent crypto-path regressions can be caught before they ship.

## Bench groups

| Group | Measures | Traceability |
|---|---|---|
| \`ed25519_verify\` | \`pk.verify(msg, sig)\` over a fixed 44-byte payload | CR-1, CR-3, RFC 8032 |
| \`dsse_parse_and_verify\` | \`DsseEnvelope::from_json\` → \`verify\` of an in-toto-shaped payload signed Ed25519 | CR-3, CR-8 |
| \`merkle_validation\` | \`verify_inclusion_proof\` for leaf 0 of complete-binary trees, parameterised \`&[8, 64, 512, 4096]\` leaves | CR-3, CR-5, CR-8 |
| \`cert_chain_validation\` | \`KeylessSignature::from_bytes\` + \`MAX_CHAIN_DEPTH\` check, parameterised \`&[1, 2, 4, 8]\` (matches audit PR #98) | CR-7, CR-8 |

## Deferred

- **SLH-DSA bench** — issue #46 (not yet implemented).
- **CI job** (sanity run on PR, full run nightly) — separate follow-up. This PR lands the harness only so baselines can be captured.
- **Full WebPKI cert-chain path** — skipped in the cert-chain bench because it needs Fulcio root + integrated_time fixtures that would dominate the measurement. The parse + length-bound is the actual pre-WebPKI hot path.

## Validation

- [x] \`cargo build -p wsc --benches\` clean
- [x] \`cargo test -p wsc --bench verification_benchmarks --release\` runs all 10 bench permutations to "Success"
- [ ] Capture numeric baselines on CI's blessed runner — done in the follow-up CI PR

Implements #89. Verifies CR-1, CR-3, CR-7, CR-8.