### PR TITLE
docs: companion docs for attestation-trust-formalization (mapping + scenarios)

### DIFF
--- a/docs/security/attestation-cerisier-mapping.md
+++ b/docs/security/attestation-cerisier-mapping.md
@@ -1,0 +1,152 @@
+# Attestation × Cerisier — vocabulary mapping
+
+Companion to [docs/security/attestation-trust-formalization.md](attestation-trust-formalization.md).
+Where the predoc explains *why* sigil needs a Cerisier-derived sister
+logic, this document specifies *which* Cerisier vocabulary each sigil
+attestation type translates into. The intended audience is anyone
+sketching the sister logic in detail; the document is descriptive, not
+prescriptive — it documents the proposed mapping, not a committed
+design.
+
+## Cerisier vocabulary recap (one screen)
+
+Recall from [docs/security/attestation-trust-formalization.md](attestation-trust-formalization.md)
+and `/Users/r/tmp/cerisier-work/cerisier-notes.md`:
+
+- **Sealing predicate `P_i`** for each enclave identity `i`, registered
+  by the verifier *before* execution, capturing the semantic invariant
+  the enclave preserves.
+- **Universal contract `𝒱(w)`** — the value-relation / "safe to share"
+  predicate, inherited from Cerise and extended with the sealed-value
+  case.
+- **Discharge lemmas `safe_to_unseal` and `safe_to_deinit`** — the
+  former trades a sealed value plus identity witness for the underlying
+  value with `P_i` discharged; the latter discharges enclave termination
+  unconditionally, backed by the CHERI-TrEE memory-sweep primitive.
+- **Capability points-to `a ↦ w` and register-bound `r ↦ᵣ w`** over the
+  machine's address space and register file.
+- **The frame rule of separation logic** — local proofs compose into
+  whole-program claims; sealed values pass through frame contexts
+  without losing their `P_i` obligation.
+
+These are the building blocks. The mapping below proposes a translation
+of sigil's attestation primitives into this vocabulary, with deliberate
+extensions where Cerisier's scope (local, atemporal, in-machine) does
+not cover sigil's (remote, time-indexed, content-addressed).
+
+## Mapping table
+
+| sigil primitive | Cerisier operator(s) | translation note |
+|---|---|---|
+| **Transformation attestation** (per pipeline stage; emitted by `meld → loom → synth → kiln`) | sealing-with-identity `P_stage` + frame composition | Each stage's transformation produces an artefact whose downstream semantic invariant is encoded as `P_stage`. The verifier registers `(stage_id, P_stage)` per stage; on successful chain verification, Cerisier's `safe_to_unseal` analog discharges that the artefact bytes satisfy `P_stage`. Chaining four such discharges along the pipeline is the frame rule: each stage's `P` survives passage through later stages' frames. The mismatch this row hides — Cerisier sees a single machine, sigil sees four separate processes over weeks — is the time-indexing gap (G1). |
+| **SLSA L4 provenance** (emitted by `release.yml` + `scripts/publish.rs`) | sealing predicate over `(builder_id, predicate_invariants)` + `safe_to_unseal` per verification step | The provenance statement is a sealed object whose identity is `builder_id` (the hardened GitHub Actions runner under SLSA L4) and whose `P_builder` captures the SLSA `predicate` requirements (hermeticity, isolation, parameter-pinning). The verifier unsealing it gets the materials + builder identity, modulo the SLSA requirement that `predicate_invariants` are satisfied. The builder is structurally an "enclave" emitting sealed claims, even though no hardware TEE is involved. The non-trivial extension is that `builder_id` is a long-lived identity, not a per-execution enclave handle. |
+| **Sigstore keyless** (OIDC → Fulcio cert → ephemeral keypair → Rekor log entry) | nested sealing `P_OIDC ⊗ P_Fulcio` + a temporal-witness predicate `P_Rekor^t` Cerisier does not natively express. **Identifies a real extension need.** | The trickiest row. Cerisier doesn't model time or remote PKI; sigil's keyless flow is fundamentally temporal (the Fulcio cert is valid for ~10 minutes; the Rekor entry's value is precisely that it pins the signature to a moment before cert expiry). Closest analog: nested sealing — the OIDC token is `P_OIDC`-sealed by the issuer, the ephemeral keypair carries a `P_Fulcio`-seal binding it to the OIDC identity, and the Rekor entry adds an inclusion-proof-bound predicate `P_Rekor^t` meaning "this seal existed at log index `t`." The sister logic must add a time-indexed predicate operator (G1) and a transparency-log inclusion predicate; neither lives in Cerisier. |
+| **Ed25519 module signature** (`src/lib/src/signature/`) | direct sealing `P_module`; the keypair is the witness for `i = module_id` | The closest fit to Cerisier's local enclave case — once you accept the Ed25519 keypair (rather than a hashed code+data identity) as the source of `i`. The seal is the signature, the witness is the verification key, `safe_to_unseal` corresponds to a successful `Ed25519.verify` call yielding the underlying message with `P_module` discharged. The honest gap is that Cerisier's sealing is abstract and machine-mediated; Ed25519 is cryptographic and detachable, so the witness can be re-presented offline by anyone who saw it once. The sister logic needs to make the witness's distribution model explicit. |
+| **SLH-DSA WIP** (FIPS 205 post-quantum signature; tracked at #46) | same as Ed25519 from Cerisier's POV — sealing is abstract; the underlying scheme is opaque. **But:** the transition between schemes is exactly where the predoc says the sister logic needs to bind. | Cerisier's sealing relation is scheme-agnostic, so SLH-DSA inherits the Ed25519 row's mapping verbatim *as long as* you stay within a single scheme. The interesting case is chains that mix Ed25519-sealed stages (pre-rotation, TS-019) with SLH-DSA-sealed stages (post-rotation, TS-020). Cerisier has no operator stating "the same identity `i` is sealed under two different schemes σ, σ', and these seals agree." This is gap G2, the load-bearing one for the PQ migration worked example. |
+
+Every cell is filled. Translation notes are 2–5 sentences per row; the
+Sigstore keyless and SLH-DSA rows carry the most extension weight.
+
+## Where Cerisier's vocabulary is insufficient
+
+This section is the load-bearing one. For each gap, state precisely
+what's missing and what extension would close it.
+
+### Time-indexed predicates (G1)
+
+Cerisier predicates `P_i` are atemporal: registration happens once and
+the predicate holds for the enclave's lifetime. Sigil chains have
+explicit timestamps in Rekor entries and in-toto `buildPlatform` /
+`metadata.buildFinishedOn` fields, and the trust meaning of a chain
+depends on those timestamps (Fulcio cert validity windows, Rekor
+monotonicity, freshness windows). A sister logic needs `P_i^t` indexed
+by a totally-ordered time domain, with rules connecting `P_i^t` and
+`P_i^t'` for `t < t'`. Iris' step-indexing `▷` is structurally similar
+but measures execution steps, not wall-clock time; whether the lift is
+semantically faithful is an open research question.
+
+### Cross-scheme transition predicates (G2)
+
+Ed25519 → SLH-DSA migration produces co-signed chains where consecutive
+links sign under different schemes for the same logical identity.
+Cerisier has no notion of "the same identity sealed under two different
+schemes." The sister logic needs either:
+
+(a) a scheme parameter on the sealing relation — `P_i^σ` for scheme
+    `σ` — plus an introduction rule `P_i^σ ∧ P_i^σ' → P_i` capturing
+    semantic agreement of the two schemes on the same identity (with
+    the appropriate soundness obligation on `σ` and `σ'`); OR
+
+(b) explicit `P_i^Ed25519 ⇒ P_i^SLH-DSA` reduction lemmas per migration
+    event, with the predoc's worked example (TS-019 → TS-020) as the
+    motivation. This option is heavier on bookkeeping but matches how
+    operators reason about real migrations today.
+
+Either form requires a notion of "scheme" first-class in the logic;
+Cerisier as written has neither.
+
+### Content-addressed artefact store (G3)
+
+Cerisier's points-to `a ↦ w` is over machine memory: mutable,
+hardware-checked, single-machine. Sigil artefacts live in OCI
+registries, Sigstore Rekor, and local content-addressed stores; they
+are immutable, globally-named-by-hash, and survive across machines
+and time. The sister logic needs `digest(w) ↦ w` over a global
+content-addressed store, plus a non-malleability lemma (no two
+distinct artefacts share a digest, modulo the collision-resistance
+assumption on the hash). Maps cleanly to Iris' authoritative-ghost-
+state pattern, but the lift is not free: revocation and GC semantics
+on a content-addressed store are subtle.
+
+### Key-rotation (G4)
+
+Cerisier has no `rotate(i_old, i_new)` primitive; its only revocation
+primitive is the memory-sweep on `EDeInit`, which is local and
+unconditional. Sigil's deployment includes legitimate key-rotation
+events (operator rotates Fulcio root, project rotates Ed25519 module-
+signing key, organisation migrates to SLH-DSA). The sister logic needs
+a rotation operator with a proof obligation that the new key's `P_i`
+matches the old key's — i.e. that rotation preserves semantic identity,
+even though cryptographic identity changes. Without this, a rotated
+chain has no formal trust-state mapping and verifiers fall back to
+ad-hoc "trust both" or "trust newest" policies.
+
+## Composition with TrustMee
+
+TrustMee (`/Users/r/tmp/cerisier-work/trustmee-notes.md`) verifies
+single-shot attestation results: a TEE hardware quote plus a signed
+Wasm verification component is reduced to a signed EAR (EAT
+Attestation Result). Where Cerisier reasons about a *chain* of sealed
+values, TrustMee provides a *verified Wasm verifier* for each link.
+The composition story:
+
+- Cerisier's `P_i` for a sigil chain stage = "this stage's attestation
+  was verified by a TrustMee-style verifier whose own attestation
+  satisfies `P_i^verifier`."
+- TrustMee's verifier emits a signed EAR; the downstream consumer
+  treats the EAR as the witness needed to discharge `P_i` via the
+  sister logic's `safe_to_unseal` analog.
+- Full picture: TrustMee covers "trust the individual verification"
+  (verifier-component soundness as engineering, no formal proof);
+  the sister logic covers "trust the composition of N verifications"
+  across the pipeline.
+
+The two pieces fit at the seam where TrustMee outputs an EAR and the
+sister logic accepts it as a witness. Neither alone suffices for
+sigil's chain.
+
+## Footnotes
+
+- Both source papers (Cerisier arXiv 2604.13638, TrustMee arXiv
+  2602.13148) were read in summary-only mode (search-engine fallback);
+  see the notes files for the caveat. Cite the notes files, not the
+  papers directly, until a real PDF read exists.
+- This document supersedes the predoc's "Three operational gaps" with
+  a more granular four-gap (G1–G4) framing. The predoc's "local vs.
+  remote attestation" framing is partially absorbed into G1 (time)
+  and G3 (content-addressed store); "no key rotation" is G4; the
+  cross-scheme transition gap (G2) is new here, pulled from the PQ-
+  migration worked example.
+- Status: **draft.** Like the predoc, research-stage; the Cerisier-
+  derived sister logic does not yet exist, and G1–G4 are the minimum
+  extension surface a first sketch must cover.

--- a/docs/security/attestation-trust-scenarios.md
+++ b/docs/security/attestation-trust-scenarios.md
@@ -1,0 +1,284 @@
+# Three trust-evolution scenarios — proposed Cerisier-style judgements
+
+Companion to [docs/security/attestation-trust-formalization.md](attestation-trust-formalization.md)
+and the vocabulary mapping document. The three scenarios below
+illustrate trust-evolution patterns that sigil's current flat
+verification model cannot answer compositionally. For each, we sketch
+a Cerisier-style judgement that the proposed sister logic would
+discharge.
+
+**Status: draft.** The sister logic does not yet exist; these
+judgements are proposed, not proven. They serve to make the predoc's
+G1–G4 gaps concrete in the language of a working proof system.
+
+## Notational conventions
+
+- `P_i` — sealing-predicate for identity `i`
+- `P_i^t` — time-indexed extension (G1 of the mapping doc)
+- `P_i^σ` — scheme-parameterised extension (G2)
+- `digest(w) ↦ w` — content-addressed points-to (G3)
+- `rotate(i_old, i_new)` — key-rotation primitive (G4)
+- `⊢ J` — the sister logic derives judgement `J`
+- `∗` — separating conjunction
+- `▷` — Iris later-modality / one possible candidate for time-indexing
+
+These are working notations; the formal sister logic may pick different
+symbols. The shape of each judgement is the substantive claim, not the
+typeface.
+
+## Scenario 1 — Cross-scheme transition during PQ migration
+
+### Setting
+
+A signing pipeline produces artefact `A_N` at stage `N` signed under
+classical **Ed25519**, and artefact `A_{N+1}` at stage `N+1` signed
+under **SLH-DSA / FIPS 205** (post-quantum). The transition is the
+expected mid-migration state — the cutover is staged, not atomic. A
+consumer receives the full chain and must decide what trust they
+have on `A_{N+1}`.
+
+### Threat scenarios mitigated
+
+- TS-019 (PQC signature stripping)
+- TS-020 (PQC negotiation downgrade)
+
+### Today's answer (sigil's flat model)
+
+The current verification walks the chain linearly. It can answer:
+"are both signatures valid?" — yes or no. It **cannot** answer:
+"given that stage N uses scheme `σ` and stage N+1 uses scheme `σ'`,
+what does the composed trust state mean?" The downgrade risk is
+implicit; the verifier has no formal handle on it.
+
+### Proposed Cerisier-style judgement
+
+```
+P_i^{Ed25519}(A_N) ∗ P_i^{SLH-DSA}(A_{N+1}) ∗ migration_witness(σ_old=Ed25519, σ_new=SLH-DSA, between=N→N+1)
+  ⊢ P_i^{post-migration}(A_{N+1})
+```
+
+In words: if (a) `A_N` carries the Ed25519-scheme sealing predicate for
+identity `i`, AND (b) `A_{N+1}` carries the SLH-DSA-scheme sealing
+predicate for the same identity, AND (c) we have a witness that the
+migration from `Ed25519` to `SLH-DSA` happened between stages `N` and
+`N+1`, then the post-migration trust predicate holds on `A_{N+1}`.
+
+The load-bearing piece is `migration_witness`: it's a first-class
+proof object that the migration was legitimate (signed under both
+schemes, or signed by a designated migration authority). Without it,
+no judgement can be derived — preventing the downgrade attack.
+
+### What would have to be added to Cerisier
+
+- The scheme parameter `σ` on the sealing predicate (extension G2)
+- A `migration_witness` type (a sigil-specific primitive)
+- The composition lemma derived from these
+
+### Detailed obligations and frame-rule role
+
+The obligation list the verifier must discharge to reach the
+conclusion is:
+
+1. **Sealing-predicate validity at the old scheme.** `P_i^{Ed25519}(A_N)`
+   must be in the context — i.e. sigil already verified the Ed25519
+   signature on `A_N` and registered `(i, Ed25519, A_N)` as a sealing
+   fact.
+2. **Sealing-predicate validity at the new scheme.** `P_i^{SLH-DSA}(A_{N+1})`
+   must be similarly in the context for the post-quantum signature.
+3. **Migration witness.** A separate proof object — itself a sealing
+   predicate with a specially-designated identity `i_migrate` — that
+   testifies "identity `i` migrated from `Ed25519` to `SLH-DSA` at the
+   gap between `N` and `N+1`". In practice this is a transparency-log
+   record (Rekor) entry co-signed under both schemes.
+
+The frame rule of separation logic is what makes this composable: the
+three premises live in disjoint resources, and once the conclusion
+fires, an unrelated downstream proof for some `A_{N+2}` does not have
+to re-walk the migration. The frame rule preserves the
+post-migration predicate as a stable assertion. Under the flat model
+sigil has today, no such stability exists — every downstream consumer
+re-walks the entire chain and is implicitly re-asking the downgrade
+question.
+
+For **TS-020 (negotiation downgrade)** the danger is that a malicious
+intermediary strips the post-quantum signature off `A_{N+1}` and
+presents only the Ed25519 chain. In the flat model the verifier sees
+"both signatures present? No → reject; only Ed25519 present? Accept,
+because Ed25519 was the historically valid scheme." The sister logic
+forbids this: the judgement's conclusion `P_i^{post-migration}` is
+*only* derivable from the SLH-DSA premise. A consumer trying to
+discharge "post-migration trust holds" with a stripped chain fails
+syntactically — there is no `P_i^{SLH-DSA}` premise to feed the rule.
+The downgrade attack becomes a proof-shaped impossibility rather than
+a policy-layer check.
+
+---
+
+## Scenario 2 — Admitted lemma in upstream proof
+
+### Setting
+
+Stage `N+1`'s attestation references a Verus proof of a property `Q`.
+The Verus proof body contains an `admit` (an unproven assumption) about
+an externally-imported function, say `external_hash`. A consumer of the
+attestation believes "we have proven `Q`," but the truth is "we have
+proven `Q` modulo the assumption that `external_hash` behaves
+correctly."
+
+### Threat scenarios mitigated
+
+Audit C-1 (the relabelled-spec issue from the 2026-04-30 audit), and
+the broader class of trust-on-faith proof references.
+
+### Today's answer
+
+Sigil's verification doesn't know about Verus admits at all — the proof
+is opaque. The consumer cannot tell whether `Q` was proven cleanly or
+modulo assumptions.
+
+### Proposed Cerisier-style judgement
+
+```
+P_i(A) carries "proof_of_Q with assumptions A_set"
+  ⊢ Trust(Q on A) = ⨅_{a ∈ A_set} Trust(a)
+```
+
+In words: the trust state on a derived property `Q` is the meet (or
+infimum, in a trust lattice) over the trust states of every assumption
+the proof depends on. The "trust lattice" is the second extension we
+need: trust isn't binary, it's ordered — proven ⪰ proven-modulo-trusted-axiom
+⪰ proven-modulo-unverified-import ⪰ unproven.
+
+### What would have to be added
+
+- A trust lattice (not in Cerisier; partially in dependent-type theories
+  like Lean4 with `Inhabited`-class typeclasses but not exactly the same)
+- A proof-carrying-attestation primitive that explicitly lists
+  assumptions (sigil could emit this today from Verus output)
+- The composition lemma: `Trust(Q) = meet over assumptions`
+
+### Worked example from audit PR #108
+
+The 2026-04-30 audit raised two related findings on Verus proofs in
+the codebase:
+
+- `lemma_le64_injective` — fully discharged: no `admit`, no `assume`,
+  no imported axiom beyond Verus's core. Under the proposed lattice,
+  its trust label is `proven`.
+- The remaining audit C-1 finding — a `proof fn` whose body contained
+  `assume(false)` to short-circuit verification under a relabelled
+  spec. Under the lattice this collapses to the bottom element
+  `unproven`, because `assume(false)` is a maximally-weak assumption
+  (it discharges everything by exploding the proof context).
+
+The judgement's force is that a consumer of the attestation can
+mechanically extract `A_set` — the list of admits, assumes, and
+imported-but-unverified externs — and compute `⨅ Trust(a)`. If any
+element of `A_set` is `assume(false)` or an opaque `extern`, the
+overall trust collapses. The audit's manual review would have been
+automated: the verifier would have rejected the attestation at
+ingestion, surfacing the relabelled-spec issue without human
+inspection of the proof body.
+
+The frame-rule role here is dual to Scenario 1: rather than carrying a
+strengthening predicate through a frame, this judgement carries a
+*weakening* (the meet over an assumption set), which propagates
+monotonically down any chain that re-uses `Q`. A downstream stage
+that builds on `Q` cannot launder away the assumption — its own
+conclusion is meet-bounded by the same `A_set`.
+
+---
+
+## Scenario 3 — Key rotation between stages
+
+### Setting
+
+The Ed25519 signing key was rotated between the signing of stage `N`
+and stage `N+1`. The old keypair `K_old` is no longer in use; the new
+keypair `K_new` is the canonical identity going forward. A consumer
+of the chain must decide whether the chain is still trustworthy.
+
+### Threat scenarios mitigated
+
+- TS-012 (Rollback — signing an old artefact under a current key to
+  re-trigger a deprecated trust state)
+- TS-021 (Verified-then-revoked — the case where `K_old` is revoked
+  after stage `N` was signed; does the chain still hold?)
+
+### Today's answer
+
+Sigil's flat verification has no notion of "key rotation event." If
+both signatures verify under their respective keys, the chain is
+accepted. The rollback risk is left to operational discipline (e.g.,
+never reuse old keys for new artefacts) rather than enforced by the
+verifier.
+
+### Proposed Cerisier-style judgement
+
+```
+P_{K_old}(A_N) ∗ P_{K_new}(A_{N+1}) ∗ rotate(K_old → K_new, at time t)
+  ⊢ Chain_Trust(A_N → A_{N+1}) ↔ (timestamp(A_N) < t < timestamp(A_{N+1}))
+```
+
+In words: chain trust survives the rotation **iff** the rotation
+happened between the two stages' timestamps. The biconditional is
+load-bearing: a rotation event whose time is outside `[timestamp(A_N),
+timestamp(A_{N+1})]` invalidates the chain — covering both rollback
+and verified-then-revoked.
+
+### What would have to be added
+
+- A first-class `rotate` primitive in the sister logic (extension G4)
+- A time-indexed sealing predicate `P_i^t` (extension G1)
+- The biconditional composition lemma
+
+### Worked example using Sigstore Rekor's `signed_entry_timestamp`
+
+In practice the time `t` is sourced from a transparency-log entry. The
+Sigstore Rekor record for the rotation event carries a
+`signed_entry_timestamp` countersigned by the log's own key, giving
+the verifier a third-party-attested time witness that the rotation
+was committed to the log at a particular moment. `timestamp(A_N)` and
+`timestamp(A_{N+1})` are likewise read from the per-artefact Rekor
+`signed_entry_timestamp` values.
+
+Discharging the judgement then reduces to three checks the sister
+logic can mechanise:
+
+1. Look up the rotation record's `signed_entry_timestamp` → `t`.
+2. Look up each artefact's `signed_entry_timestamp` → `t_N`, `t_{N+1}`.
+3. Verify the strict inequality `t_N < t < t_{N+1}`.
+
+Failure modes the biconditional explicitly catches:
+
+- **Rollback (TS-012).** An attacker re-signs old content `A_N'` under
+  `K_new` at present-day `t' > t_{N+1}`. Then `timestamp(A_N') > t`,
+  so the rotation event is *before* `A_N'` and the left-hand side of
+  the iff is false. Chain trust does not hold.
+- **Verified-then-revoked (TS-021).** `K_old` is revoked at `t_rev`
+  with `t_rev < t_N`. Then the rotation effectively happened before
+  `A_N` was signed, so `t < t_N`, the inequality fails, and the chain
+  is rejected — even though both individual signatures verify.
+
+The Iris later-modality `▷` is a natural fit for `P_i^t`: a
+sealing-predicate guarded by `▷^k` is one whose validity is asserted
+only after `k` steps of logical time, lining up with the
+step-indexed model Iris already supports. Whether `▷` carries enough
+expressive power for *real* wall-clock comparisons or whether the
+sister logic needs a richer time-monoid is an open design question
+for the Iris embedding.
+
+---
+
+## What these three scenarios show
+
+Together, the three scenarios cover the predoc's G1 (time), G2 (cross-
+scheme), G3 is implicit in the content-addressed nature of sigil
+artefacts, and G4 (key rotation). The mapping document's table breaks
+down which sigil primitives need which extensions; this document shows
+*why* each extension is load-bearing — i.e. what concrete threat scenario
+each enables.
+
+A sister logic that supports just the four extensions G1-G4 layered
+on Cerisier's core would let sigil's verifier discharge all three
+judgements. None of the three is currently derivable in the flat model.


### PR DESCRIPTION
Adds two companion documents to the existing predoc \`docs/security/attestation-trust-formalization.md\`:

## 1. \`attestation-cerisier-mapping.md\` (1559 words)

Translates each sigil attestation primitive into the closest Cerisier program-logic operator. Five-row mapping table:

| sigil primitive | Cerisier operator(s) |
|---|---|
| Transformation attestation (meld → loom → synth → kiln) | sealing-with-identity + frame composition |
| SLSA L4 provenance | sealing predicate + \`safe_to_unseal\` |
| Sigstore keyless (OIDC → Fulcio → Rekor) | Nested sealing — identifies the biggest extension need |
| Ed25519 module signature | Direct sealing \`P_module\` |
| SLH-DSA WIP | Same as Ed25519 from Cerisier's POV; cross-scheme transition is the gap |

Identifies four extension gaps (**G1** time-indexed predicates, **G2** cross-scheme transitions, **G3** content-addressed store, **G4** key rotation) where Cerisier's local-attestation scope doesn't cover sigil's needs.

## 2. \`attestation-trust-scenarios.md\` (1791 words)

Three concrete trust-evolution scenarios sigil cannot answer compositionally today, each with a proposed Cerisier-style judgement:

- **Scenario 1** — cross-scheme PQ migration (mitigates TS-019, TS-020)
- **Scenario 2** — admits in upstream proof chain (audit C-1 with concrete \`lemma_le64_injective\` worked example)
- **Scenario 3** — key rotation between stages (mitigates TS-012, TS-021)

## Status

Both documents are **draft / research-stage**. The sister logic does not yet exist; these are the design sketch that would precede an Iris/Rocq mechanisation. The companion blog post on pulseengine.eu (separate repo) summarises the public-facing argument.

## Source caveat

Both papers (Cerisier arXiv 2604.13638, TrustMee arXiv 2602.13148) were read in WebSearch-only mode in this session because WebFetch was sandbox-blocked for the agents. Full PDF reads remain pending — same caveat the predoc carries.

## Companion artefacts (not in this PR)

- pulseengine.eu blog post: \`2026-05-11-attestation-chains-trustmee-to-cerisier.md\` (separate repo)
- Local working notes: \`/Users/r/tmp/cerisier-work/{cerisier-notes,trustmee-notes}.md\` (intentionally local)