### PR TITLE
release: v0.8.4 — Fulcio cert pin rotation hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,58 @@
 All notable changes to sigil are documented here. The project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] — 2026-05-19
+
+Hotfix release. Single-commit content: rotate the pinned Fulcio leaf
+SPKI to the new Sigstore-issued cert.
+
+### Why this exists
+
+v0.8.3 tagged cleanly and shipped to crates.io, but the
+`release.yml::Build & Release WASM Component` job failed (and so the
+GitHub Release object for v0.8.3 was never created) because Sigstore
+rotated the `fulcio.sigstore.dev` leaf certificate between the pin
+set's last update (2026-04-14, leaf `6611c54b...`) and the v0.8.3
+release date (2026-05-16, observed leaf `e30da317...`). The keyless
+signing flow correctly fail-closed on the pin mismatch.
+
+This release bumps the version, lands the pin fix from PR #119, and
+re-triggers `release.yml` at a tag (v0.8.4) whose code does contain
+the new pin. The crates.io packages already at 0.8.3 are unaffected;
+v0.8.4 will publish over them as the canonical version going forward.
+
+### Changed
+
+- `src/lib/src/signature/keyless/cert_pinning.rs` —
+  `FULCIO_PRODUCTION_PINS` adds the new leaf SPKI
+  `e30da317897121cb8fba4b1285d4d51207dfbe6272c245bc1c19694317658275`.
+  Verified by direct `openssl s_client` fetch; chain identity
+  (subject CN, issuer `Google Trust Services WR3`) cross-checked.
+  Previous leaf retained for transition / rollback safety. GTS WR3
+  intermediate pin and Rekor leaf pin both unchanged and re-verified.
+
+### Audit observation
+
+The v0.8.3 release-blocking failure provided strong evidence that
+audit C-4 (issue #95) was partly mis-framed: cert pinning **is**
+enforced today on the keyless HTTP path (post-handshake check, fail-
+closed), even though it is not enforced at the rustls handshake
+layer. The right framing for #95 is "move enforcement to the
+handshake layer for defense-in-depth", not "enable enforcement".
+
+### Operational follow-up (issue thread)
+
+A scheduled "compare live SPKI vs pinned set" job would surface the
+next Sigstore rotation **before** it blocks a release rather than
+after. Tracked as a follow-up to #117 (already filed and closed by
+this PR), not blocking.
+
+### Contributors
+
+PRs in this release: #119 (Fulcio pin rotation).
+
+[0.8.4]: https://github.com/pulseengine/sigil/compare/v0.8.3...v0.8.4
+
 ## [0.8.3] — 2026-05-16
 
 Audit-followup continuation. Closes the residual security-ignore-list

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,7 +4721,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsc"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-attestation"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-cli"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "clap",
  "env_logger",
@@ -4800,7 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-component"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "wit-bindgen 0.47.0",
  "wsc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 authors = ["Frank Denis <github@pureftpd.org>", "Ralf Anton Beier <ralf_beier@me.com>"]
 license = "MIT"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@
 module(
     name = "wsc",
     # Keep in sync with [workspace.package].version in Cargo.toml.
-    version = "0.8.3",
+    version = "0.8.4",
 )
 
 # Dependencies

--- a/src/cli/BUILD.bazel
+++ b/src/cli/BUILD.bazel
@@ -15,7 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 # Version info - keep in sync with [workspace.package].version in Cargo.toml
 # and with the `version` field in MODULE.bazel.
-VERSION = "0.8.3"
+VERSION = "0.8.4"
 
 rust_binary(
     name = "wasmsign_cli",


### PR DESCRIPTION
Single-commit-content release that re-cuts the v0.8.3 release at a tag whose code does contain the Fulcio pin fix from PR #119. v0.8.3 itself shipped to crates.io but its GitHub Release object was never created because the WASM Component signing failed on the stale pin. This release fixes that.

Closes #117 (already closed by #119; mentioned here for traceability). See CHANGELOG.md for the full release notes.