### PR TITLE
chore: gitignore /audit/ working notes directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ wasmsign2
 # Nix / direnv
 .direnv/
 result
+
+# Local audit working notes (intentionally untracked — formal findings
+# land in docs/security/ once distilled).
+/audit/


### PR DESCRIPTION
## Summary
- Adds `/audit/` to `.gitignore` so local audit working notes stop polluting `git status`.

## Context
Each audit cycle leaves a working directory under `audit/YYYY-MM-DD/` with quickstart, findings, and notes that are intentionally NOT committed — the distilled findings land in `docs/security/` (e.g. `attestation-cerisier-mapping.md`, `attestation-trust-scenarios.md`) via dedicated PRs once the audit is consolidated.

Anchoring with a leading slash so only top-level `audit/` is ignored.

## Test plan
- [x] `git status` shows clean tree after adding `audit/2026-04-30/`
- [ ] CI green (workflow_run on chore/* branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)