### PR TITLE
ci: add Sigstore certificate pin watchdog

### DIFF
--- a/.github/workflows/cert-pin-watch.yml
+++ b/.github/workflows/cert-pin-watch.yml
@@ -1,0 +1,107 @@
+# Certificate pin watchdog.
+#
+# Sigstore rotates the fulcio.sigstore.dev / rekor.sigstore.dev leaf
+# certificates roughly every 90 days. When that happens, the SPKI pins
+# embedded in src/lib/src/signature/keyless/cert_pinning.rs go stale and
+# the keyless signing flow fail-closes — which has twice blocked a release
+# (see issue #117). This job fetches the live leaf SPKI daily and compares
+# it against the pinned set, so a rotation surfaces as a tracked issue
+# *before* it blocks a release rather than after.
+
+name: Certificate Pin Watchdog
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Daily at 06:00 UTC.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-pins:
+    name: Compare live Sigstore SPKI vs pinned set
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Compare live leaf SPKI against the pinned set
+      id: compare
+      run: |
+        set -uo pipefail
+        PIN_FILE="src/lib/src/signature/keyless/cert_pinning.rs"
+        status=0
+        report=""
+        for host in fulcio.sigstore.dev rekor.sigstore.dev; do
+          echo "::group::$host"
+          # SHA-256 of the leaf certificate's SubjectPublicKeyInfo (DER).
+          # This is the same value pinned in cert_pinning.rs — it survives
+          # certificate renewals as long as the public key is unchanged.
+          live=$(echo | openssl s_client -connect "$host:443" -servername "$host" 2>/dev/null \
+            | openssl x509 -pubkey -noout 2>/dev/null \
+            | openssl pkey -pubin -outform DER 2>/dev/null \
+            | openssl dgst -sha256 -binary 2>/dev/null \
+            | xxd -p -c 256) || true
+          if [ -z "$live" ]; then
+            echo "::warning::could not fetch live SPKI for $host (transient network failure?)"
+            report="${report}- ${host}: SPKI fetch failed\n"
+            status=1
+            echo "::endgroup::"
+            continue
+          fi
+          echo "live leaf SPKI: $live"
+          if grep -qi "$live" "$PIN_FILE"; then
+            echo "OK — live SPKI is present in $PIN_FILE"
+          else
+            echo "::error::PIN DRIFT — $host live leaf SPKI is not in $PIN_FILE"
+            report="${report}- ${host}: live leaf SPKI ${live} is NOT in the pinned set\n"
+            status=1
+          fi
+          echo "::endgroup::"
+        done
+        printf 'report<<EOF\n%b\nEOF\n' "$report" >> "$GITHUB_OUTPUT"
+        exit $status
+
+    - name: Open a tracking issue on drift
+      if: failure()
+      uses: actions/github-script@v7
+      env:
+        # Passed via env (not ${{ }} interpolation) so the report text can
+        # never break out of the script — workflow-injection-safe pattern.
+        DRIFT_REPORT: ${{ steps.compare.outputs.report }}
+      with:
+        script: |
+          const marker = '[cert-pin-watchdog]';
+          const issues = await github.paginate(github.rest.issues.listForRepo, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+          });
+          if (issues.some(i => i.title.includes(marker))) {
+            core.info('A cert-pin-watchdog issue is already open; not filing a duplicate.');
+            return;
+          }
+          const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const report = process.env.DRIFT_REPORT || '(see the workflow run for details)';
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `${marker} Sigstore certificate pin drift detected`,
+            body: [
+              'The certificate pin watchdog found a live Sigstore leaf SPKI that is',
+              'not in the pinned set, or could not verify one.',
+              '',
+              report,
+              '',
+              'If this is a genuine Sigstore rotation, update `FULCIO_PRODUCTION_PINS`',
+              '/ `REKOR_PRODUCTION_PINS` in',
+              '`src/lib/src/signature/keyless/cert_pinning.rs` and cut a patch release',
+              'before the stale pin blocks the next release build.',
+              '',
+              `Watchdog run: ${run}`,
+            ].join('\n'),
+          });


### PR DESCRIPTION
## Summary
Adds a daily scheduled workflow (`.github/workflows/cert-pin-watch.yml`) that fetches the live `fulcio.sigstore.dev` / `rekor.sigstore.dev` leaf SPKI and compares it against `FULCIO_PRODUCTION_PINS` / `REKOR_PRODUCTION_PINS` in `cert_pinning.rs`.

## Why
Sigstore rotates the Fulcio/Rekor leaf certs roughly every 90 days. A stale SPKI pin fail-closes the keyless signing flow — this has **blocked a release twice** (#117, and the v0.8.3 → v0.8.4 hotfix where the WASM-component signing job failed on a rotated leaf). The watchdog surfaces a rotation *before* it blocks a release: on drift it fails the job and opens a single deduplicated tracking issue.

## Notes
- Triggers: `schedule` (daily 06:00 UTC) + `workflow_dispatch`. No untrusted event inputs.
- The drift report is passed to `actions/github-script` via `env:` (not `${{ }}` interpolation) — workflow-injection-safe.
- Issue creation is deduplicated by a `[cert-pin-watchdog]` title marker.

## Test plan
- [x] Comparison logic run locally — both live SPKIs (`e30da317…` Fulcio, `356aacac…` Rekor) currently match the pinned set, so the job passes today and fires only on real drift.
- [ ] `workflow_dispatch` run after merge to confirm the green path in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)