### PR TITLE
ci: expand nightly fuzz — 10 targets, 30-min budget each

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ on:
       duration:
         description: 'Fuzzing duration per target (seconds)'
         required: false
-        default: '300'
+        default: '1800'
 
 jobs:
   fuzz:
@@ -25,6 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # All 10 cargo-fuzz targets declared in `fuzz/Cargo.toml`. The
+        # matrix had silently fallen behind as new targets were added —
+        # keep this list in sync with `fuzz/Cargo.toml [[bin]]` entries.
         target:
           - fuzz_varint
           - fuzz_keyless_signature
@@ -32,6 +35,10 @@ jobs:
           - fuzz_signature_data
           - fuzz_public_key
           - fuzz_rekor_entry
+          - fuzz_dsse_envelope
+          - fuzz_elf_parsing
+          - fuzz_format_detection
+          - fuzz_mcuboot_parsing
 
     steps:
       - name: Checkout repository
@@ -47,11 +54,22 @@ jobs:
         run: mkdir -p fuzz/corpus/${{ matrix.target }}
 
       - name: Run fuzzer
+        env:
+          # Default 30-minute budget per target for the nightly schedule
+          # (previously 5 min). On manual dispatch the workflow input
+          # overrides this. The matrix runs all 10 targets in parallel on
+          # smithy lean-mem runners so wall-clock stays ~30 min while
+          # per-target depth rises 6×. Inputs interpolated via env: to
+          # keep the matrix value out of the shell template (workflow-
+          # injection-safe pattern).
+          DEFAULT_DURATION: '1800'
+          DURATION_INPUT: ${{ github.event.inputs.duration }}
+          TARGET: ${{ matrix.target }}
         run: |
           cd fuzz
-          DURATION=${{ github.event.inputs.duration || '300' }}
-          echo "Fuzzing ${{ matrix.target }} for ${DURATION} seconds..."
-          cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=$DURATION
+          DURATION="${DURATION_INPUT:-$DEFAULT_DURATION}"
+          echo "Fuzzing ${TARGET} for ${DURATION} seconds..."
+          cargo +nightly fuzz run "${TARGET}" -- -max_total_time="${DURATION}"
         continue-on-error: true
 
       - name: Upload crash artifacts


### PR DESCRIPTION
## Summary
Two small drift fixes to `fuzz.yml`:

1. **Matrix had silently fallen behind.** `fuzz/Cargo.toml` declares **10** \`[[bin]]\` targets; the workflow matrix only ran **6**. The four missing — \`fuzz_dsse_envelope\`, \`fuzz_elf_parsing\`, \`fuzz_format_detection\`, \`fuzz_mcuboot_parsing\` — were not being fuzzed at all. Added to the matrix.
2. **Per-target duration: 300 s → 1800 s.** Five-minute budget per target was the original \"prove it runs\" setting; the matrix already runs in parallel on smithy \`lean-mem\` self-hosted runners so wall-clock stays ~30 min while per-target depth rises 6×. \`workflow_dispatch\` input override unchanged.

Also tightens the shell template: matrix value now passed via \`env:\` instead of \`${{ }}\` interpolation inside the \`run:\` block (same workflow-injection-safe pattern the cert-pin watchdog uses).

## Why
\`fuzz.yml\` runs nightly on smithy and is the project's main continuous-fuzzing surface. Drift between \`fuzz/Cargo.toml\` and the workflow matrix is the kind of thing that silently degrades coverage — the four omitted targets cover ELF/MCUboot/format-detection/DSSE-envelope parsing surfaces that are explicitly security-critical.

## Follow-ups (intentionally out of scope here)
- **Corpus persistence across runs** via \`actions/cache\` keyed on the target — current setup uploads corpus as an artifact (7-day retention) but does not feed it back into the next run.
- **Auto-file an issue on crash** using the dedup-by-title-marker pattern from the cert-pin watchdog, so crashes surface in the issue tracker not just in CI logs.
- **OSS-Fuzz enrollment** for the variety-of-fuzzer benefit (libFuzzer + AFL++ + Honggfuzz) and external visibility, on top of the in-house smithy nightly.

## Test plan
- [x] YAML lints / matrix syntax review
- [ ] CI run — confirm all 10 targets execute on the new schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)