### PR TITLE
release: v0.9.1 — close two #135-class keyless verify bypasses + STPA-Sec report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,27 +3,66 @@
 All notable changes to sigil are documented here. The project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.9.1] — 2026-05-25
+
+Security release. Closes two verification-bypass gaps in the keyless
+verify path that allowed `wsc verify --keyless` to return exit 0 on
+modules the cert holder did not sign. Both gaps were of the same
+"load-bearing property never enforced" class — the verifier had
+*structure* matching the intended checks but was missing the actual
+hash / cross-reference comparisons.
 
 ### Fixed (security)
 
-- **`wsc verify --keyless` now actually binds the signature to the
-  artifact** (#135). Previous versions back through v0.9.0 verified the
-  Fulcio certificate chain and the Rekor SET, then accepted the module
-  without recomputing its hash or checking the embedded ECDSA signature
-  against the leaf cert's public key. Any tampered module — including
-  one with a byte flipped inside its signed payload, or one whose
-  signature section was spliced in from a different artifact — would
-  return exit 0. The new `KeylessSignature::verify_artifact_binding`
-  closes both halves of the gap (hash recompute + ECDSA verify under
-  the leaf cert's SPKI) and is wired into `KeylessVerifier::verify` as
-  a mandatory step between Rekor SET verification and identity claims.
-  Seven new tamper-rejection unit tests in
-  `src/lib/src/signature/keyless/format.rs` cover the byte-flip,
-  signature-substitution, hash-substitution, cert-substitution,
-  missing-signature-section, and empty-chain cases. Downstream consumers
-  (synth #140) that asserted the tampered-rejection property as an
-  xfail can now flip back to a positive assertion.
+- **Artifact binding** (#135 / PR #136). `KeylessVerifier::verify`
+  verified the Fulcio cert chain and Rekor SET but never recomputed
+  the module hash or ECDSA-verified the signature against the leaf
+  cert. A tampered module — byte flipped, signature section spliced in
+  from a different artifact — returned exit 0. The new
+  `KeylessSignature::verify_artifact_binding` strips the signature
+  section, recomputes `SHA256`, and `verify_digest`s the signature
+  under the leaf cert's SPKI. Wired as step 4 of `verify()`.
+- **Rekor body binding (UCA-2)** (#135 / PR #136). The verify path
+  proved the Rekor entry was logged by Rekor, but never decoded the
+  entry's `body` to check that the logged `(hash, signature, public
+  key)` triple actually referenced *this* bundle. An attacker holding
+  any legitimate Fulcio cert could sign a malicious module and embed
+  any unrelated public Rekor entry to pass verification — the original
+  attack class re-emerges one layer up. The new
+  `KeylessSignature::verify_rekor_body_binds_to_bundle` decodes the
+  hashedrekord JSON body and asserts (a) `body.spec.data.hash.value ==
+  hex(module_hash)`, (b) `body.spec.signature.content == signature`,
+  (c) the leaf cert DER from `body.spec.signature.publicKey.content`
+  byte-equals the bundle's leaf cert DER. Wired as step 5 of `verify()`.
+
+Both checks emit `WSError::VerificationFailed` with a `log::error!`
+identifying the specific mismatch; the error variant deliberately does
+not discriminate, so an attacker cannot probe which leg of the check
+rejected their forgery. Seventeen new tamper-rejection unit tests in
+`src/lib/src/signature/keyless/format.rs` cover byte-flip,
+signature-substitution, hash-substitution, cert-substitution,
+missing-signature-section, empty-chain, artifact-hash mismatch,
+signature-content mismatch, public-key mismatch, unsupported
+kind / apiVersion / hash-algorithm, garbage / non-JSON body, and
+uppercase-hex-hash acceptance.
+
+Downstream consumers (synth #140 case 3) that asserted the tampered-
+rejection property as an xfail can flip back to a positive assertion
+once they pick up this release.
+
+### Documented
+
+- New STPA-Sec report at `docs/security/stpa-keyless-2026-05-25.md` enumerating
+  the five UCAs identified in the analysis that produced this release:
+  UCA-1 (Rekor inclusion proof never run on verify path), UCA-2 (fixed
+  here), UCA-3 (cert validity bound to attacker-pickable
+  `integrated_time`), UCA-4 (cache hit skips SET re-verify without
+  bundle-equality check), UCA-5 (audit log records hash from
+  silently-discarded serialize error). Each UCA includes a code
+  citation, the STPA-4 questions, a loss scenario, suggested fix, and
+  the verification trail that confirms the finding against HEAD.
+  UCA-1, UCA-3, UCA-4, UCA-5 remain open and are tracked as follow-up
+  issues.
 
 ## [0.9.0] — 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to sigil are documented here. The project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed (security)
+
+- **`wsc verify --keyless` now actually binds the signature to the
+  artifact** (#135). Previous versions back through v0.9.0 verified the
+  Fulcio certificate chain and the Rekor SET, then accepted the module
+  without recomputing its hash or checking the embedded ECDSA signature
+  against the leaf cert's public key. Any tampered module — including
+  one with a byte flipped inside its signed payload, or one whose
+  signature section was spliced in from a different artifact — would
+  return exit 0. The new `KeylessSignature::verify_artifact_binding`
+  closes both halves of the gap (hash recompute + ECDSA verify under
+  the leaf cert's SPKI) and is wired into `KeylessVerifier::verify` as
+  a mandatory step between Rekor SET verification and identity claims.
+  Seven new tamper-rejection unit tests in
+  `src/lib/src/signature/keyless/format.rs` cover the byte-flip,
+  signature-substitution, hash-substitution, cert-substitution,
+  missing-signature-section, and empty-chain cases. Downstream consumers
+  (synth #140) that asserted the tampered-rejection property as an
+  xfail can now flip back to a positive assertion.
+
 ## [0.9.0] — 2026-05-20
 
 Cleanup-cycle release: a criterion benchmark regression gate and a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,7 +4721,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-attestation"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "clap",
  "env_logger",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-component"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "wit-bindgen 0.47.0",
  "wsc",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-verify-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ct-codecs",
  "ed25519-compact",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["Frank Denis <github@pureftpd.org>", "Ralf Anton Beier <ralf_beier@me.com>"]
 license = "MIT"

--- a/docs/security/stpa-keyless-2026-05-25.md
+++ b/docs/security/stpa-keyless-2026-05-25.md
@@ -1,0 +1,368 @@
+# STPA-Sec on the keyless verification subsystem — 2026-05-25
+
+Triggered by issue #135 (`wsc verify --keyless` accepted tampered WASM).
+Systems-Theoretic Process Analysis (security extension) applied to
+`src/lib/src/signature/keyless/` and the verify CLI dispatch at
+`src/cli/main.rs:895–917`. Read-only analysis; all findings independently
+verified against the code at HEAD of branch `fix/keyless-verify-binds-artifact`
+before being reported here.
+
+PRs landing fixes from this analysis:
+- **PR #136** (this branch): closes the original #135 finding +
+  **UCA-2** below.
+
+Outstanding work tracked as separate issues:
+- **UCA-1** → see #137 (file when triaging)
+- **UCA-3** → see #138
+- **UCA-4** → see #139
+- **UCA-5** → see #140
+
+## 1. Subsystem under analysis
+
+The keyless signature verification path of `sigil`/`wsc`: the code that,
+when a user runs `wsc verify --keyless <module.wasm>`, decides whether to
+return exit 0 or exit non-zero. Rooted at `KeylessVerifier::verify()`
+(`src/lib/src/signature/keyless/signer.rs:554–678`), dispatched from
+`src/cli/main.rs:899–917`.
+
+## 2. Losses and hazards
+
+| ID | Description |
+|---|---|
+| **L1** | Verifier returns success on a module the cert holder did not sign. |
+| **L2** | Verifier returns success on a module whose contents differ from what the cert holder signed. |
+| **L3** | Verifier returns success despite the cert/identity/issuer being attacker-controlled or expired. |
+| **L4** | Verifier returns success when Rekor evidence is missing, forged, stale, or refers to a different artifact. |
+| **L5** | A signature blob is replayable across artifacts, identities, or time windows beyond design intent. |
+| **L6** | Audit log records an artifact hash that does not match what was verified, breaking forensic traceability. |
+
+Hazards (worst-case system states that lead to losses):
+- **H-A** A control action that should gate the outcome on a property is never invoked.
+- **H-B** A control action observes attacker-supplied feedback as if it were trusted.
+- **H-C** A cached decision is reused across requests that do not share the cached property's scope.
+- **H-D** A property is checked against fields the attacker can independently set.
+
+## 3. Control structure
+
+```
+                +---------------------------+
+                |   CLI verb 'verify'       |
+                |   src/cli/main.rs:895-917 |
+                +-------------+-------------+
+                              | constructs KeylessVerifier::new()
+                              v
+  +-------------------------------------------------------+
+  |  KeylessVerifier::verify()  signer.rs:554-678         |
+  |---|extract_signature|--|verify_cert_chain|--|SET|--|  |
+  |                                       |--|cache|--|  |
+  |                                            |verify_artifact_binding|
+  |                                            |verify_rekor_body_binds_to_bundle  ← NEW (UCA-2)
+  +---|-----------------|----------------|--------|------+
+      v                 v                v        v
+  extract_signature  cert_pool         RekorKeyring    KeylessSignature
+  (signer.rs:498)    .verify_pem_cert  .verify_set     .verify_artifact_binding
+                     (cert_verifier.rs (rekor_verifier  (format.rs:483)
+                     :194)             .rs:498)        .verify_rekor_body_binds_to_bundle
+                                       (NOT verify_inclusion_proof!)  (format.rs, new)
+
+Controlled processes: candidate Module bytes, OS exit code, audit log.
+
+Feedback consumed:
+  - cert_chain (attacker-controlled until pinned root chains it)
+  - rekor_entry.signed_entry_timestamp + body + integrated_time + log_id
+    (attacker-controlled before SET check; Rekor-bound after SET check)
+  - signature (P-256 sig, attacker-controlled)
+  - module_hash field stored in signature (attacker-controlled until
+    artifact-binding check)
+  - candidate module bytes (attacker-controlled)
+```
+
+## 4. Verified UCAs
+
+### UCA-1 — Rekor Merkle inclusion proof is never verified on the production verify path
+
+**Status:** open. Tracked as issue.
+
+- **Mapped losses:** L4, L5
+- **Code citation:** `signer.rs:583–623` (`KeylessVerifier::verify`); the
+  missing call would be `keyless_sig.verify_rekor_inclusion()` defined at
+  `format.rs:437` but never invoked.
+- **STPA-4 questions:**
+  1. Provided when it shouldn't be? — N/A
+  2. **Not provided when it should be? — YES.** Only `RekorKeyring::verify_set`
+     runs (`signer.rs:612`). `verify_inclusion_proof`
+     (`rekor_verifier.rs:724`) is never reached.
+  3. Too early/late? — N/A
+  4. Stopped too soon? — In the sense that SET-only is treated as the
+     full Rekor proof: yes.
+- **Loss scenario:** Rekor's SET only attests "Rekor signed this
+  `(body, integratedTime, logID, logIndex)` tuple at some point." It
+  does **not** prove inclusion in the Merkle tree. A misbehaving Rekor
+  instance, a Rekor key-compromise, or a Rekor operator producing
+  parallel "side log" entries that are signed but never integrated would
+  pass `verify_set`. SLSA L4 non-falsifiability is dropped.
+- **Suggested fix:** After `verify_set` succeeds at `signer.rs:612`, also
+  call `verifier.verify_inclusion_proof(&keyless_sig.rekor_entry)?`. Cache
+  the verified inclusion proof in the same cache slot (see UCA-4 for
+  cache-consumption semantics).
+- **Verification trail:**
+  - `grep -n "verify_inclusion_proof\|verify_rekor_inclusion\|verify_entry" src/lib/src/signature/keyless/signer.rs` → 0 hits.
+  - `grep -rn 'verify_rekor_inclusion'` → only `format.rs:452` (definition)
+    and `format.rs:787` (unit test). No production caller.
+- **Cross-ref:** Strengthens audit **C-5** from 2026-04-30. C-5 framed
+  this as "inclusion-proof failures silently downgraded to SET-only
+  fallback" — the actual code is stronger: there is no inclusion-proof
+  attempt at all from `verify()`, so nothing to fall back from.
+
+### UCA-2 — Rekor body field never decoded or cross-referenced with the bundle (FIXED IN PR #136)
+
+**Status:** closed by PR #136.
+
+- **Mapped losses:** L4, L5
+- **Code citation (before fix):** `signer.rs:554–678`;
+  `grep -rn "rekor_entry.body" src/lib/src/signature/keyless/ | grep -v test`
+  returned only `rekor_verifier.rs:544,754,755` (SET canonicalisation
+  and inclusion-proof leaf-hash inputs), never a comparison against the
+  artifact's signature or pubkey.
+- **STPA-4 questions:**
+  1. Provided when it shouldn't be? — N/A
+  2. **Not provided when it should be? — YES.**
+  3. Too early/late? — N/A
+  4. Stopped too soon? — Yes; SET verification stopped before body
+     interpretation.
+- **Loss scenario (concrete):** An attacker
+  1. Generates a fresh ECDSA P-256 keypair.
+  2. Requests a *legitimate* Fulcio cert for their own OIDC identity —
+     any signed-in GitHub/Google user can do this; no privilege needed.
+  3. Signs malicious module M' with their key.
+  4. Constructs a `KeylessSignature` with their genuine signature,
+     their genuine cert chain, `module_hash = SHA256(M')`, **and any
+     unrelated public Rekor entry** — e.g., the entry for someone else's
+     hello-world module from 2024.
+  5. Runs `wsc verify --keyless`. All gates pass:
+     - `extract_signature` ✓
+     - `verify_cert_chain` ✓ (the cert is real)
+     - `verify_set` ✓ (the borrowed Rekor entry is real)
+     - `verify_artifact_binding` ✓ (PR #136 only proves bundle-internal
+       consistency — the attacker's sig really does verify against M'
+       under their cert)
+     - identity/issuer ✓ (defaults to None on the CLI; attacker's
+       identity is *displayed*, not constrained)
+  6. Exit 0. A consumer reading "verified successfully" trusts the
+     artifact. The Rekor entry referenced a completely different artifact.
+- **Fix landed (PR #136):** `KeylessSignature::verify_rekor_body_binds_to_bundle`
+  decodes the hashedrekord body and asserts three equalities:
+  1. `body.spec.data.hash.algorithm == "sha256"` and
+     `body.spec.data.hash.value == hex(self.module_hash)`.
+  2. `base64_decode(body.spec.signature.content) == self.signature`.
+  3. Leaf cert DER from
+     `base64_decode(body.spec.signature.publicKey.content)` byte-equals
+     the bundle's leaf cert DER (PEM-parsed for normalisation).
+
+  Wired into `KeylessVerifier::verify` as step 5, between artifact
+  binding and identity-claim checks. Ten new unit tests cover happy
+  path + each tamper type.
+- **Verification trail (before fix):**
+  - `grep -rn "rekor_entry.body\|entry.body" src/lib/src/signature/keyless/ | grep -v test`
+    → only SET canonicalisation and leaf-hash inputs.
+  - Read of `verify_set` (`rekor_verifier.rs:498–573`) confirms `body`
+    passed verbatim into JCS canonicalisation; never parsed as
+    hashedrekord.
+
+### UCA-3 — Cert validity window is bound to attacker-pickable `integrated_time`
+
+**Status:** open. Tracked as issue.
+
+- **Mapped losses:** L3, L5
+- **Code citation:** `format.rs:396–415` parses `integrated_time` from
+  `self.rekor_entry.integrated_time` and uses it as the
+  `verification_time` passed to WebPKI's `verify_for_usage` via
+  `CertificatePool::verify_pem_cert` (`cert_verifier.rs:194–238`).
+- **STPA-4 questions:**
+  1. Provided when it shouldn't be? — N/A
+  2. Not provided when it should be? — Partially; missing is "is this
+     `integrated_time` bound to *this* artifact?"
+  3. **Too early/late? — YES.** Cert validity is checked at a moment the
+     attacker chooses (by selecting which Rekor entry to embed), not at
+     the moment this artifact was signed.
+  4. Stopped too soon? — N/A
+- **Loss scenario:** Builds on UCA-2. Attacker's Fulcio cert was valid
+  for, say, 10 minutes on 2025-03-01 (Fulcio short-lived certs). The
+  cert has now expired. The attacker generates a new malicious module M',
+  signs it with the *expired* cert's still-held private key, and
+  packages it with any Rekor entry whose `integrated_time` falls within
+  the cert's old validity window. Since `integrated_time` drives the
+  WebPKI verification clock (`format.rs:402,412`), the cert appears valid.
+
+  After PR #136 closes UCA-2, this attack collapses to "you also have to
+  control a Rekor entry whose body matches your bundle." Forging such an
+  entry is hard, but cherry-picking an old `integrated_time` for a body
+  the attacker controls remains a partial loss of forward security.
+- **Suggested fix:** Tie cert-validity time to a field bound to the
+  artifact. The natural fix is to use the Rekor entry's logged time
+  (now safely bound to the bundle after UCA-2) but additionally verify
+  the cert was valid at *signing* time per the body's logged signature,
+  not just at *log integration* time.
+- **Verification trail:** Re-read `format.rs:396–415` and
+  `cert_verifier.rs:194–238`; `integrated_time` flows directly into
+  `UnixTime::since_unix_epoch(...)` with no artifact-bound anchoring.
+- **Cross-ref:** Adjacent to audit **H-3** but a different shape — H-3
+  is about clock manipulation; this is about which clock the verifier
+  reads.
+
+### UCA-4 — Proof cache hit skips SET re-verification with no bundle-equality check
+
+**Status:** open. Tracked as issue.
+
+- **Mapped losses:** L4, L5
+- **Code citation:** `signer.rs:593–623`; cache key construction at
+  `signer.rs:594–597`; cache definition at `proof_cache.rs:36–60`.
+- **STPA-4 questions:**
+  1. **Provided when it shouldn't be? — YES.** On cache hit, SET
+     re-verification is skipped (`signer.rs:609`); the cached
+     `RekorEntry` itself is *not consulted at all* — note
+     `let Some(_cached_proof) = cache.get(&cache_key)` at `signer.rs:600`,
+     where the cached proof is bound to `_` and discarded.
+  2. Not provided when it should be? — Yes (re-validation that the
+     cached entry's `body` matches the current bundle).
+  3. **Too early/late? — YES.** The cache is consulted *before* SET, but
+     the key is only `(SHA256(signed_module_bytes), keyless_sig.rekor_entry.uuid)`,
+     both attacker-controllable, and `keyless_sig.rekor_entry` is *not*
+     asserted to equal the cached `RekorEntry`.
+  4. Stopped too soon? — N/A
+- **Loss scenario:** Combine with UCA-2 (pre-fix) or with a not-yet-found
+  partial UCA-2 bypass. Suppose a legitimate signed module M was cached
+  after a successful network verification — the cache holds
+  `(hash(M), uuid_X) -> CachedProof { entry: real_entry_X }`. An
+  attacker constructs a new bundle: keeps the same signed module bytes M
+  (so `hash(M)` is unchanged) but mutates the *embedded* `keyless_sig`
+  so its `rekor_entry` is `RekorEntry { uuid: "uuid_X", body: <forged>, ... }`.
+  Because the cache key is `(hash(M), "uuid_X")`, the cache hits; SET
+  re-verification is skipped; the cached `CachedProof` is discarded
+  (`_cached_proof`); the verifier proceeds with the attacker's *mutated*
+  `keyless_sig.rekor_entry` for downstream extraction.
+
+  Today (post-PR-#136) the downstream consumer is identity/issuer
+  extraction + body cross-check. UCA-2 fix means the forged body must
+  still match the bundle — but the cache made the SET check itself
+  irrelevant, which loses one layer of defence in depth.
+- **Suggested fix:** Either (a) use the cached `CachedProof.entry` for
+  downstream steps, replacing `keyless_sig.rekor_entry` so the cache
+  becomes authoritative; or (b) on cache hit, assert
+  `cached_proof.entry == keyless_sig.rekor_entry` before skipping the
+  network round-trip; or (c) make the cache key include a hash of
+  `keyless_sig.rekor_entry` itself, not just its `uuid`.
+- **Verification trail:** Read `signer.rs:599–607`; `_cached_proof`
+  explicitly discarded. Cache key at `signer.rs:594–597` shows only
+  `(hash_hex, uuid)`. `proof_cache.rs:34–60` confirms `CacheKey` has no
+  signature/body field.
+- **Cross-ref:** Adjacent to **H-5** but a distinct failure mode
+  (consumption-side rather than population-side).
+
+### UCA-5 — Audit log records artifact hash from silently-discarded serialize error
+
+**Status:** open. Tracked as issue.
+
+- **Mapped losses:** L6
+- **Code citation:** `signer.rs:569–573`:
+
+  ```rust
+  let mut module_bytes = Vec::new();
+  module.serialize(&mut module_bytes).ok();        // error swallowed
+  let module_hash = Sha256::digest(&module_bytes); // hash over possibly-empty vec
+  let artifact_hash = format!("sha256:{}", hex::encode(&module_hash));
+  ```
+- **STPA-4 questions:**
+  1. Provided when it shouldn't be? — Yes; the audit-logged
+     `artifact_hash` is recorded as if authoritative.
+  2. Not provided when it should be? — Yes; the verifier swallows a
+     serialization failure that should abort.
+  3. Too early/late? — N/A
+  4. Stopped too soon? — Yes; `.ok()` discards the `Result`.
+- **Loss scenario:** If `module.serialize` errors (e.g., on a malformed
+  input the serializer cannot round-trip), `module_bytes` remains empty
+  and the audit log writes
+  `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+  (SHA-256 of empty) as the "artifact hash that was verified." Forensics
+  on the audit trail sees an empty-hash record. The cache key
+  (`signer.rs:594–597`) uses the same `module_hash`, so all such error
+  cases share a single cache slot — observable collision.
+
+  The artifact-binding step (`format.rs:495–499`) uses its own
+  serialization that propagates errors, so this is **not** a verification
+  bypass — but it is a correctness gap and audit-trail integrity loss.
+- **Suggested fix:** Replace `.ok()` with `?`; or compute the audit-hash
+  from the stripped-bytes already produced inside `verify_artifact_binding`.
+- **Verification trail:** `signer.rs:569–573`; `module.serialize(...)`
+  returns `Result<(), CoreError>` (`src/verify-core/src/wasm_module/mod.rs:323`).
+  Cache key reuse confirmed at `signer.rs:594–597`.
+- **Cross-ref:** Not in prior audit. Novel.
+
+## 5. Cross-reference to existing audit
+
+| This report | Prior audit (`audit/2026-04-30/findings.md`) | Relationship |
+|---|---|---|
+| UCA-1 | **C-5** | Same root cause; this report finds gap is broader (inclusion not attempted, not just degraded). |
+| UCA-2 | none | Novel. Most direct #135-class gap. **Closed by PR #136.** |
+| UCA-3 | adjacent to **H-3** | Different shape — H-3 is clock manipulation; UCA-3 is artifact-bound time-source choice. |
+| UCA-4 | adjacent to **H-5** | Different shape — H-5 is cache population; UCA-4 is cache consumption. |
+| UCA-5 | none | Novel. Audit-trail correctness, not verification correctness. |
+
+## 6. Speculative items not verified
+
+- **Multi-SAN selection** (`format.rs:249–268`): `get_identity()` returns
+  the first `RFC822Name` SAN. Behaviour under multi-identity SANs
+  unverified; depends on Fulcio policy.
+- **`module.serialize` determinism**: `verify_artifact_binding` recomputes
+  the hash by stripping then re-serializing. Byte-exact reversibility
+  across `deserialize → strip → serialize` for all valid inputs not
+  verified (e.g., custom sections with non-canonical varint encoding).
+- **Section-ordering ambiguity**: `extract_signature` (`signer.rs:498–512`)
+  uses `.find()`; `detach_signature` (`split.rs:70–88`) requires FIRST
+  section to be signature header. If a module had two custom sections
+  both named `"signature"`, the helpers would disagree. Could not
+  construct a verifying attack (both fail-closed) but worth pinning down.
+- **`module.clone()` inside `verify_artifact_binding`** (`format.rs:491–494`):
+  could not confirm there are no `Module` fields whose `Clone` impl
+  loses information relevant to serialization.
+
+## 7. What this analysis explicitly cleared
+
+- **Skip-Rekor sentinel** (`signer.rs:587–591`) correctly rejects modules
+  signed with `skip_rekor=true` before the cache path. Confirmed against
+  `rekor.rs:45–50`.
+- **Empty cert chain on artifact binding** (`format.rs:516–519`)
+  fails-closed with `VerificationFailed` even though `verify()` already
+  catches it. Defence-in-depth holds (test at `format.rs:1136–1145`).
+- **Chain depth bound** (`format.rs:387–389`) caps at `MAX_CHAIN_DEPTH = 8`
+  before any x509 parsing. 100-cert synthetic test (`format.rs:835–854`)
+  confirms rejection at the depth guard. Closes audit H-2 in keyless scope.
+- **Negative `integrated_time`** (`cert_verifier.rs:221–226`) explicitly
+  rejected before the `i64 → u64` cast — bypass via wrap-to-future
+  closed.
+- **Tampered-byte detection (PR #136)**: `verify_artifact_binding`
+  (`format.rs:483–571`) catches all four bundle-tampering attacks its
+  test suite demonstrates: byte flip, corrupted signature, substituted
+  `module_hash`, substituted cert. Original #135 attack class is closed.
+- **Rekor body cross-check (PR #136)**: `verify_rekor_body_binds_to_bundle`
+  (`format.rs`) catches the cross-binding gap of UCA-2 — body's
+  `data.hash`, `signature.content`, and `signature.publicKey` must all
+  match bundle. Tests for each tamper case.
+- **Issuer normalisation on signing** (`signer.rs:322–331`) normalises
+  trailing slashes (closes audit AS-13). Slight inconsistency vs verify
+  path (`signer.rs:651–660` uses exact match) but neither is
+  over-permissive.
+- **Rekor SET signing-key fingerprint mismatch** (`rekor_verifier.rs:585–609`)
+  validates checkpoint signature's key fingerprint against keyring.
+- **Empty `signed_entry_timestamp` rejection** (`rekor_verifier.rs:499–503`)
+  rejects on empty SET. Note: only fires in non-cache branch — see UCA-4.
+
+## Out-of-scope observations (noted, not elaborated)
+
+- `src/lib/src/sct.rs:124–131` is a non-functional stub with placeholder
+  CT-log keys, and `keyless/` never invokes the SCT verifier — Fulcio's
+  embedded SCTs are entirely unchecked. Separate subsystem; deserves its
+  own STPA. Touches audit L-4 / SC-26.
+- DSSE/attestation paths, airgapped bundle verification, and the
+  traditional `pk.verify` path (`src/cli/main.rs:919–962`) were not
+  analysed. They deserve their own STPA passes.

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -32,5 +32,5 @@ regex = "1.12.2"
 # HTTP client for keyless signing
 ureq = { version = "3.1.2" }
 wasi = { version = "0.14.7" }
-wsc = { version = "0.9.0", path = "../lib" }
+wsc = { version = "0.9.1", path = "../lib" }
 serde_json = "1.0"

--- a/src/component/Cargo.toml
+++ b/src/component/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Core signing library
-wsc = { version = "0.9.0", path = "../lib" }
+wsc = { version = "0.9.1", path = "../lib" }
 
 # WIT bindings generation
 wit-bindgen = { version = "0.47.0", default-features = false, features = ["realloc"] }

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["cryptography", "wasm"]
 [dependencies]
 # Verification core (carved out so it builds for wasm32 with no TLS/X.509 deps).
 # wsc re-exports its public API for backwards compatibility.
-wsc-verify-core = { version = "0.9.0", path = "../verify-core" }
+wsc-verify-core = { version = "0.9.1", path = "../verify-core" }
 # Re-export attestation types from minimal crate
-wsc-attestation = { version = "0.9.0", path = "../attestation" }
+wsc-attestation = { version = "0.9.1", path = "../attestation" }
 anyhow = "1.0.100"
 ct-codecs = "1.1.6"
 ed25519-compact = { version = "2.1.1", features = ["pem"] }

--- a/src/lib/src/signature/keyless/format.rs
+++ b/src/lib/src/signature/keyless/format.rs
@@ -1,6 +1,8 @@
 use crate::Module;
 use crate::error::WSError;
 use crate::wasm_module::varint;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use serde::Deserialize;
 use serde_json;
 use sha2::{Digest, Sha256};
 use std::io::{Cursor, Write};
@@ -10,6 +12,49 @@ use x509_parser::prelude::*;
 use super::cert_verifier::CertificatePool;
 pub use super::rekor::RekorEntry;
 use super::rekor_verifier::RekorKeyring;
+
+/// Deserialization view of the Rekor `hashedrekord/0.0.1` entry body.
+///
+/// Only the fields needed to bind the entry to a candidate
+/// [`KeylessSignature`] bundle are modeled — extra fields in the body are
+/// permitted and ignored. The signer side at `rekor.rs::upload_entry`
+/// produces this exact shape.
+#[derive(Debug, Deserialize)]
+struct HashedrekordBody {
+    kind: String,
+    #[serde(rename = "apiVersion")]
+    api_version: String,
+    spec: HashedrekordSpec,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashedrekordSpec {
+    signature: HashedrekordSignature,
+    data: HashedrekordData,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashedrekordSignature {
+    content: String,
+    #[serde(rename = "publicKey")]
+    public_key: HashedrekordPublicKey,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashedrekordPublicKey {
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashedrekordData {
+    hash: HashedrekordHash,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashedrekordHash {
+    algorithm: String,
+    value: String,
+}
 
 /// Binary format version for keyless signatures
 pub const KEYLESS_VERSION: u8 = 0x02;
@@ -569,6 +614,186 @@ impl KeylessSignature {
         log::debug!("Keyless artifact binding verified successfully");
         Ok(())
     }
+
+    /// Verify that the Rekor entry's body binds to *this* bundle.
+    ///
+    /// [`verify_artifact_binding`](Self::verify_artifact_binding) proves
+    /// the signature, leaf cert and module are mutually consistent.
+    /// [`verify_rekor_inclusion`](Self::verify_rekor_inclusion) (and the
+    /// SET check used by [`KeylessVerifier`](super::signer::KeylessVerifier))
+    /// prove the Rekor entry was logged by Rekor. Neither proves the
+    /// Rekor entry actually references *this* bundle — without that
+    /// binding, an attacker with any valid Fulcio cert can sign a
+    /// malicious module and stuff in **any unrelated** Rekor entry, and
+    /// `verify --keyless` returns exit 0 (issue #135 UCA-2).
+    ///
+    /// This check decodes the entry body — a base64'd `hashedrekord/0.0.1`
+    /// JSON document — and asserts three equalities against the bundle:
+    ///
+    /// 1. `body.spec.data.hash.algorithm == "sha256"` and
+    ///    `body.spec.data.hash.value == hex(self.module_hash)`.
+    /// 2. `base64_decode(body.spec.signature.content) == self.signature`.
+    /// 3. The leaf certificate parsed from
+    ///    `base64_decode(body.spec.signature.publicKey.content)` matches
+    ///    `self.cert_chain[0]` byte-for-byte at the DER level.
+    ///
+    /// All failures return [`WSError::VerificationFailed`] with a
+    /// `log::error!` describing the specific mismatch; the error variant
+    /// itself does not discriminate, to avoid giving an attacker an
+    /// oracle for which leg of the check rejected their forgery.
+    pub fn verify_rekor_body_binds_to_bundle(&self) -> Result<(), WSError> {
+        // 1. Decode the body and shape-check kind/version. Rekor's API
+        // returns the body as base64-encoded JSON; the signer side at
+        // `rekor.rs::upload_entry` builds it as `hashedrekord/0.0.1`.
+        let body_bytes = BASE64.decode(&self.rekor_entry.body).map_err(|e| {
+            log::error!(
+                "Rekor body binding rejected: body is not valid base64: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+
+        let body: HashedrekordBody = serde_json::from_slice(&body_bytes).map_err(|e| {
+            log::error!(
+                "Rekor body binding rejected: body is not a hashedrekord JSON: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+
+        if body.kind != "hashedrekord" {
+            log::error!(
+                "Rekor body binding rejected: unexpected kind '{}', want 'hashedrekord'",
+                body.kind
+            );
+            return Err(WSError::VerificationFailed);
+        }
+        if body.api_version != "0.0.1" {
+            log::error!(
+                "Rekor body binding rejected: unsupported hashedrekord apiVersion '{}', \
+                 want '0.0.1'",
+                body.api_version
+            );
+            return Err(WSError::VerificationFailed);
+        }
+
+        // 2. Artifact hash equality: body says what was logged, bundle
+        // carries what was signed. Without this, an attacker can pair
+        // their signature over module M' with someone else's Rekor
+        // entry that logged a different hash for module M.
+        if body.spec.data.hash.algorithm.to_ascii_lowercase() != "sha256" {
+            log::error!(
+                "Rekor body binding rejected: unsupported hash algorithm '{}', want 'sha256'",
+                body.spec.data.hash.algorithm
+            );
+            return Err(WSError::VerificationFailed);
+        }
+        let bundle_hash_hex = hex::encode(&self.module_hash);
+        if !body
+            .spec
+            .data
+            .hash
+            .value
+            .eq_ignore_ascii_case(&bundle_hash_hex)
+        {
+            log::error!(
+                "Rekor body binding rejected: body artifact hash '{}' does not match bundle \
+                 module_hash '{}'",
+                body.spec.data.hash.value,
+                bundle_hash_hex,
+            );
+            return Err(WSError::VerificationFailed);
+        }
+
+        // 3. Signature blob equality: body says which signature was
+        // logged, bundle carries which signature is being presented.
+        // Without this, an attacker can splice a body whose hash happens
+        // to match but whose recorded signature came from a different
+        // signing event.
+        let body_sig = BASE64.decode(&body.spec.signature.content).map_err(|e| {
+            log::error!(
+                "Rekor body binding rejected: body signature is not valid base64: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+        if body_sig.as_slice() != self.signature.as_slice() {
+            log::error!(
+                "Rekor body binding rejected: body signature bytes do not match bundle \
+                 signature (body_len={}, bundle_len={})",
+                body_sig.len(),
+                self.signature.len(),
+            );
+            return Err(WSError::VerificationFailed);
+        }
+
+        // 4. Public-key binding: the body's publicKey.content is a
+        // base64'd PEM that the signer uploaded as
+        // `cert_chain.join("\n")`. Different Rekor clients could
+        // serialize cert chain joining differently, so the robust check
+        // is to extract the leaf CERTIFICATE block from the decoded
+        // bytes, parse it to DER, and compare to the bundle's leaf cert
+        // (also normalised via PEM→DER). Direct byte equality on the
+        // raw PEM would over-reject on benign whitespace / line-ending
+        // differences.
+        let body_pubkey_bytes = BASE64
+            .decode(&body.spec.signature.public_key.content)
+            .map_err(|e| {
+                log::error!(
+                    "Rekor body binding rejected: body publicKey is not valid base64: {}",
+                    e
+                );
+                WSError::VerificationFailed
+            })?;
+        let body_leaf_der = first_certificate_der(&body_pubkey_bytes).ok_or_else(|| {
+            log::error!(
+                "Rekor body binding rejected: body publicKey contains no CERTIFICATE PEM block"
+            );
+            WSError::VerificationFailed
+        })?;
+
+        let bundle_leaf_pem = self.cert_chain.first().ok_or_else(|| {
+            log::error!("Rekor body binding rejected: bundle has no leaf certificate");
+            WSError::VerificationFailed
+        })?;
+        let bundle_leaf_der =
+            first_certificate_der(bundle_leaf_pem.as_bytes()).ok_or_else(|| {
+                log::error!(
+                    "Rekor body binding rejected: bundle leaf cert is not a parseable PEM \
+                     CERTIFICATE block"
+                );
+                WSError::VerificationFailed
+            })?;
+
+        if body_leaf_der != bundle_leaf_der {
+            log::error!(
+                "Rekor body binding rejected: body leaf cert DER differs from bundle leaf \
+                 cert DER (body_len={}, bundle_len={})",
+                body_leaf_der.len(),
+                bundle_leaf_der.len(),
+            );
+            return Err(WSError::VerificationFailed);
+        }
+
+        log::debug!("Rekor body binding verified successfully");
+        Ok(())
+    }
+}
+
+/// Parse a PEM-encoded byte slice and return the DER bytes of the first
+/// CERTIFICATE block. Returns `None` if no CERTIFICATE block is present
+/// or the PEM is malformed. Used to normalise leaf-cert comparison
+/// across serializations that may differ on whitespace or trailing
+/// concatenated certs.
+fn first_certificate_der(pem_bytes: &[u8]) -> Option<Vec<u8>> {
+    // Use the absolute path `::pem` because `x509_parser::prelude::*`
+    // brings in a `pem` module that would otherwise shadow the crate.
+    for entry in ::pem::parse_many(pem_bytes).ok()?.into_iter() {
+        if entry.tag() == "CERTIFICATE" {
+            return Some(entry.contents().to_vec());
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -964,19 +1189,24 @@ mod tests {
         let signature: p256::ecdsa::Signature = signing_key.sign_digest(hasher.clone());
         let module_hash = hasher.finalize().to_vec();
 
-        // 4. Build the KeylessSignature blob and embed it. The Rekor entry
-        // is fixture data — `verify_artifact_binding` does not consult it.
+        // 4. Build the hashedrekord body matching the bundle so the
+        // Rekor body-binding check has a real document to validate.
+        // The signer side at `rekor.rs::upload_entry` constructs this
+        // exact shape; we mirror it byte-for-byte.
+        let sig_bytes_vec = signature.to_bytes().to_vec();
+        let body_json = build_hashedrekord_body(&sig_bytes_vec, &cert_pem, &module_hash);
+
         let rekor_entry = RekorEntry {
             uuid: "fixture-rekor-uuid".to_string(),
             log_index: 1,
-            body: String::new(),
+            body: body_json,
             log_id: "fixture-log-id".to_string(),
             inclusion_proof: vec![],
             signed_entry_timestamp: String::new(),
             integrated_time: "2026-01-01T00:00:00Z".to_string(),
         };
         let keyless_sig = KeylessSignature::new(
-            signature.to_bytes().to_vec(),
+            sig_bytes_vec,
             vec![cert_pem.clone()],
             rekor_entry,
             module_hash,
@@ -1000,6 +1230,34 @@ mod tests {
             keyless_sig,
             other_cert_pem: other_cert.pem(),
         }
+    }
+
+    /// Build a `hashedrekord/0.0.1` body JSON matching the inputs and
+    /// return it base64-encoded (as the Rekor API returns it).
+    fn build_hashedrekord_body(
+        signature_bytes: &[u8],
+        leaf_cert_pem: &str,
+        module_hash: &[u8],
+    ) -> String {
+        let body = serde_json::json!({
+            "kind": "hashedrekord",
+            "apiVersion": "0.0.1",
+            "spec": {
+                "signature": {
+                    "content": BASE64.encode(signature_bytes),
+                    "publicKey": {
+                        "content": BASE64.encode(leaf_cert_pem.as_bytes()),
+                    },
+                },
+                "data": {
+                    "hash": {
+                        "algorithm": "sha256",
+                        "value": hex::encode(module_hash),
+                    },
+                },
+            },
+        });
+        BASE64.encode(serde_json::to_vec(&body).expect("body to JSON"))
     }
 
     #[test]
@@ -1142,5 +1400,186 @@ mod tests {
             .verify_artifact_binding(&fx.signed_module)
             .expect_err("empty cert chain must be rejected");
         assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    // -----------------------------------------------------------------
+    // Rekor body-binding tests for issue #135 UCA-2
+    //
+    // verify_artifact_binding (above) closes the "cert+sig+module
+    // mutually consistent" gap. These tests close the orthogonal gap:
+    // the embedded Rekor entry's `body` must actually reference *this*
+    // bundle. Each test takes the fully-bound fixture, mutates one
+    // field of the body (artifact hash, signature, or public key), and
+    // asserts rejection.
+    // -----------------------------------------------------------------
+
+    /// Re-encode a hashedrekord body after applying a mutation to its
+    /// JSON value. Returns the new base64-encoded body string.
+    fn remunge_body<F: FnOnce(&mut serde_json::Value)>(body_b64: &str, mutate: F) -> String {
+        let raw = BASE64.decode(body_b64).expect("body is base64");
+        let mut body: serde_json::Value = serde_json::from_slice(&raw).expect("body is JSON");
+        mutate(&mut body);
+        BASE64.encode(serde_json::to_vec(&body).expect("body to JSON"))
+    }
+
+    #[test]
+    fn test_verify_rekor_body_binding_accepts_consistent_body() {
+        let fx = build_artifact_binding_fixture();
+        fx.keyless_sig
+            .verify_rekor_body_binds_to_bundle()
+            .expect("consistent hashedrekord body must verify");
+    }
+
+    /// Attacker takes a legitimately-signed module's signature blob but
+    /// embeds an unrelated Rekor entry that logged a *different* artifact.
+    /// `verify_artifact_binding` accepts the bundle (cert+sig+module are
+    /// self-consistent), but the body's `data.hash.value` does not
+    /// match the bundle's `module_hash` — must reject.
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_artifact_hash_mismatch() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = remunge_body(&tampered.rekor_entry.body, |body| {
+            body["spec"]["data"]["hash"]["value"] = serde_json::json!(
+                "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            );
+        });
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("body artifact-hash mismatch must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// Body's recorded signature differs from the bundle's signature —
+    /// catches the case where an attacker borrows a Rekor entry whose
+    /// logged signature came from a different signing event over the
+    /// same hash.
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_signature_mismatch() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = remunge_body(&tampered.rekor_entry.body, |body| {
+            // Substitute a different base64 blob of the same length.
+            let bogus = BASE64.encode(vec![0x42u8; 64]);
+            body["spec"]["signature"]["content"] = serde_json::json!(bogus);
+        });
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("body signature mismatch must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// Body's recorded public key refers to a different cert than the
+    /// bundle's leaf — catches the case where an attacker borrows a
+    /// Rekor entry that logged a different identity's signature over
+    /// the same hash and signature blob.
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_public_key_mismatch() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        let other_pubkey_b64 = BASE64.encode(fx.other_cert_pem.as_bytes());
+        tampered.rekor_entry.body = remunge_body(&tampered.rekor_entry.body, |body| {
+            body["spec"]["signature"]["publicKey"]["content"] =
+                serde_json::json!(other_pubkey_b64);
+        });
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("body public-key mismatch must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// Unsupported kind / apiVersion / hash algorithm must reject —
+    /// guards against future Rekor types whose semantics this verifier
+    /// hasn't been taught to interpret.
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_unsupported_kind() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = remunge_body(&tampered.rekor_entry.body, |body| {
+            body["kind"] = serde_json::json!("intoto");
+        });
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("unsupported kind must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_unsupported_api_version() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = remunge_body(&tampered.rekor_entry.body, |body| {
+            body["apiVersion"] = serde_json::json!("99.0.0");
+        });
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("unsupported apiVersion must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_non_sha256_hash_algorithm() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = remunge_body(&tampered.rekor_entry.body, |body| {
+            body["spec"]["data"]["hash"]["algorithm"] = serde_json::json!("md5");
+        });
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("non-sha256 hash must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// Malformed inputs (non-base64 body, non-JSON body, malformed
+    /// inner base64 fields) must fail-closed with the same error
+    /// variant — never panic, never accept.
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_garbage_body() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = "this is not base64 either".to_string();
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("garbage body must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    #[test]
+    fn test_verify_rekor_body_binding_rejects_non_json_body() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = BASE64.encode(b"not json at all");
+
+        let err = tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect_err("non-JSON body must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// Case-insensitivity check: Rekor sometimes returns hex hashes
+    /// uppercase or mixed case. The check must accept those (genuine
+    /// data) but still reject when bytes truly differ.
+    #[test]
+    fn test_verify_rekor_body_binding_accepts_uppercase_hex_hash() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered = fx.keyless_sig.clone();
+        tampered.rekor_entry.body = remunge_body(&tampered.rekor_entry.body, |body| {
+            let v = body["spec"]["data"]["hash"]["value"]
+                .as_str()
+                .unwrap()
+                .to_ascii_uppercase();
+            body["spec"]["data"]["hash"]["value"] = serde_json::json!(v);
+        });
+
+        tampered
+            .verify_rekor_body_binds_to_bundle()
+            .expect("uppercase hex hash must still verify");
     }
 }

--- a/src/lib/src/signature/keyless/format.rs
+++ b/src/lib/src/signature/keyless/format.rs
@@ -1,6 +1,8 @@
+use crate::Module;
 use crate::error::WSError;
 use crate::wasm_module::varint;
 use serde_json;
+use sha2::{Digest, Sha256};
 use std::io::{Cursor, Write};
 use x509_parser::prelude::*;
 
@@ -45,13 +47,17 @@ pub const MAX_CHAIN_DEPTH: usize = 8;
 /// ```
 #[derive(Debug, Clone)]
 pub struct KeylessSignature {
-    /// Ed25519 signature over the module hash
+    /// ECDSA P-256 signature over `SHA256(module_bytes_without_signature_section)`,
+    /// produced by the ephemeral key whose public half is in the leaf of
+    /// [`cert_chain`](Self::cert_chain). Serialized in IEEE P1363 form (r || s).
     pub signature: Vec<u8>,
     /// X.509 certificate chain from Fulcio (PEM format)
     pub cert_chain: Vec<String>,
     /// Rekor transparency log entry
     pub rekor_entry: RekorEntry,
-    /// SHA256 hash of the WASM module that was signed
+    /// SHA256 of the module **before** the keyless signature custom section
+    /// was attached. Verifiers must recompute this from the candidate module
+    /// (after stripping the signature section) and reject on mismatch.
     pub module_hash: Vec<u8>,
 }
 
@@ -448,6 +454,121 @@ impl KeylessSignature {
         log::debug!("Rekor inclusion proof verified successfully");
         Ok(())
     }
+
+    /// Verify that this signature actually binds to the given module.
+    ///
+    /// This is the artifact-integrity step of keyless verification. It is
+    /// **independent of** certificate chain validation and Rekor SET
+    /// verification, which only attest to "this Fulcio cert exists and is
+    /// known to the transparency log." Without this check, an attacker who
+    /// obtains any valid Fulcio cert + Rekor entry can splice the signature
+    /// blob onto an arbitrary module and the verifier will accept it
+    /// (issue #135).
+    ///
+    /// Two checks run in sequence; failing either rejects the module:
+    ///
+    /// 1. **Hash binding.** Strip the embedded signature custom section,
+    ///    serialize the remaining module, recompute its SHA-256, and require
+    ///    it to equal [`Self::module_hash`]. This proves the candidate
+    ///    module's bytes are the bytes the signer covered.
+    /// 2. **Signature authenticity.** Extract the ECDSA P-256 public key
+    ///    from the leaf certificate and verify [`Self::signature`] is a
+    ///    valid signature over `SHA256(stripped_module_bytes)`. This proves
+    ///    the cert's holder actually signed *this* hash, not someone else's.
+    ///
+    /// On any failure, returns [`WSError::VerificationFailed`] and emits a
+    /// `log::error!` with the specific reason. The error variant does not
+    /// distinguish hash vs. signature failure to avoid leaking which check
+    /// a tampered artifact tripped.
+    pub fn verify_artifact_binding(&self, module: &Module) -> Result<(), WSError> {
+        use ecdsa::signature::DigestVerifier;
+        use p256::ecdsa::{Signature as P256Signature, VerifyingKey};
+
+        // Step 1: Recompute the module hash over the bytes the signer
+        // covered (i.e., the module with the signature custom section
+        // removed). The sign path computes the hash *before* attaching the
+        // signature, so verify must mirror that by stripping it.
+        let (unsigned_module, _stripped_signature_bytes) = module
+            .clone()
+            .detach_signature()
+            .map_err(|_| WSError::NoSignatures)?;
+
+        let mut unsigned_bytes = Vec::new();
+        unsigned_module.serialize(&mut unsigned_bytes).map_err(|e| {
+            WSError::InternalError(format!("Failed to serialize stripped module: {}", e))
+        })?;
+
+        let recomputed_hash = Sha256::digest(&unsigned_bytes);
+        if &recomputed_hash[..] != self.module_hash.as_slice() {
+            log::error!(
+                "Keyless artifact binding rejected: module hash mismatch \
+                 (expected {}, recomputed {})",
+                hex::encode(&self.module_hash),
+                hex::encode(recomputed_hash),
+            );
+            return Err(WSError::VerificationFailed);
+        }
+
+        // Step 2: Extract the leaf cert's SPKI as a P-256 verifying key and
+        // verify the signature blob against the recomputed digest. The sign
+        // path uses `signing_key.sign_digest(Sha256)` with the same module
+        // bytes — verify must use `verify_digest` symmetrically.
+        let leaf_pem = self.cert_chain.first().ok_or_else(|| {
+            log::error!("Keyless artifact binding rejected: empty certificate chain");
+            WSError::VerificationFailed
+        })?;
+
+        let (_, pem) = parse_x509_pem(leaf_pem.as_bytes()).map_err(|e| {
+            log::error!(
+                "Keyless artifact binding rejected: failed to parse leaf cert PEM: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+        let cert = pem.parse_x509().map_err(|e| {
+            log::error!(
+                "Keyless artifact binding rejected: failed to parse leaf X.509: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+
+        // Fulcio issues ECDSA P-256 keys (matching the sign path at
+        // signer.rs `SigningKey::<p256::NistP256>::random`). The SPKI's
+        // BIT STRING `data` field is the SEC1-encoded uncompressed point
+        // (0x04 || x || y) for P-256, which `from_sec1_bytes` accepts.
+        let spki_bits = cert.public_key().subject_public_key.data.as_ref();
+        let verifying_key = VerifyingKey::from_sec1_bytes(spki_bits).map_err(|e| {
+            log::error!(
+                "Keyless artifact binding rejected: leaf cert SPKI is not a valid \
+                 ECDSA P-256 key: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+
+        let signature = P256Signature::from_slice(&self.signature).map_err(|e| {
+            log::error!(
+                "Keyless artifact binding rejected: signature blob is not a valid \
+                 ECDSA P-256 signature: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(&unsigned_bytes);
+        verifying_key.verify_digest(hasher, &signature).map_err(|e| {
+            log::error!(
+                "Keyless artifact binding rejected: ECDSA verify failed: {}",
+                e
+            );
+            WSError::VerificationFailed
+        })?;
+
+        log::debug!("Keyless artifact binding verified successfully");
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -765,5 +886,261 @@ mod tests {
 
         assert_eq!(deserialized.module_hash.len(), 32);
         assert_eq!(deserialized.module_hash, sig.module_hash);
+    }
+
+    // -----------------------------------------------------------------
+    // Artifact-binding tests for issue #135
+    //
+    // These tests reproduce the class of tampering the original verifier
+    // accepted (signature blob present and well-formed, but the artifact
+    // bytes don't match what the cert holder actually signed). Each test
+    // builds a real cert with a real ECDSA P-256 keypair, signs a real
+    // module, then mutates one piece of the bundle and asserts rejection.
+    // -----------------------------------------------------------------
+
+    /// Test fixture: a real WASM module + a KeylessSignature whose cert,
+    /// signature, and module_hash all consistently bind to that module.
+    /// Calling [`verify_artifact_binding`] on `(signed_module, keyless_sig)`
+    /// must succeed; tamper any one piece and it must fail.
+    struct ArtifactBindingFixture {
+        signed_module: crate::Module,
+        keyless_sig: KeylessSignature,
+        /// A second, independently-generated cert chain (with a different
+        /// public key) for the "swap the cert" tamper test.
+        other_cert_pem: String,
+    }
+
+    fn build_artifact_binding_fixture() -> ArtifactBindingFixture {
+        use crate::wasm_module::{Module, Section, StandardSection, SectionId};
+        use ecdsa::signature::DigestSigner;
+        use p256::pkcs8::DecodePrivateKey;
+
+        // 1. Build a realistic-enough module: WASM magic + version, plus a
+        // standard section so the hash covers more than just the header.
+        let module = Module {
+            header: [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+            sections: vec![
+                Section::Standard(StandardSection::new(
+                    SectionId::Type,
+                    vec![0x01, 0x60, 0x00, 0x00],
+                )),
+                Section::Standard(StandardSection::new(
+                    SectionId::Function,
+                    vec![0x01, 0x00],
+                )),
+                Section::Standard(StandardSection::new(
+                    SectionId::Code,
+                    vec![0x01, 0x04, 0x00, 0x41, 0x2a, 0x0b],
+                )),
+            ],
+        };
+
+        // 2. Generate an ECDSA P-256 keypair via rcgen, then re-import the
+        // PKCS#8 PEM into p256 so we can both (a) mint a real cert that
+        // embeds the public key and (b) sign the module hash with the
+        // matching private key. Going rcgen→p256 avoids hand-rolling
+        // PKCS#8 export from p256.
+        let cert_keypair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
+            .expect("rcgen keypair generation");
+        let signing_key_pem = cert_keypair.serialize_pem();
+        let secret = p256::SecretKey::from_pkcs8_pem(&signing_key_pem)
+            .expect("p256 import of rcgen PKCS8 PEM");
+        let signing_key = ecdsa::SigningKey::<p256::NistP256>::from(&secret);
+
+        let params = rcgen::CertificateParams::new(vec!["fixture.local".to_string()])
+            .expect("cert params");
+        let cert = params.self_signed(&cert_keypair).expect("self-signed cert");
+        let cert_pem = cert.pem();
+
+        // 3. Sign the module hash exactly the way `KeylessSigner::sign_module` does.
+        let mut module_bytes = Vec::new();
+        module
+            .clone()
+            .serialize(&mut module_bytes)
+            .expect("module serialize");
+
+        let mut hasher = Sha256::new();
+        hasher.update(&module_bytes);
+        let signature: p256::ecdsa::Signature = signing_key.sign_digest(hasher.clone());
+        let module_hash = hasher.finalize().to_vec();
+
+        // 4. Build the KeylessSignature blob and embed it. The Rekor entry
+        // is fixture data — `verify_artifact_binding` does not consult it.
+        let rekor_entry = RekorEntry {
+            uuid: "fixture-rekor-uuid".to_string(),
+            log_index: 1,
+            body: String::new(),
+            log_id: "fixture-log-id".to_string(),
+            inclusion_proof: vec![],
+            signed_entry_timestamp: String::new(),
+            integrated_time: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let keyless_sig = KeylessSignature::new(
+            signature.to_bytes().to_vec(),
+            vec![cert_pem.clone()],
+            rekor_entry,
+            module_hash,
+        );
+
+        let sig_blob = keyless_sig.to_bytes().expect("keyless sig serialize");
+        let signed_module = module.attach_signature(&sig_blob).expect("attach signature");
+
+        // 5. Mint an unrelated cert with a different keypair for the
+        // cert-substitution test.
+        let other_keypair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
+            .expect("other keypair");
+        let other_params = rcgen::CertificateParams::new(vec!["other.local".to_string()])
+            .expect("other params");
+        let other_cert = other_params
+            .self_signed(&other_keypair)
+            .expect("other self-signed");
+
+        ArtifactBindingFixture {
+            signed_module,
+            keyless_sig,
+            other_cert_pem: other_cert.pem(),
+        }
+    }
+
+    #[test]
+    fn test_verify_artifact_binding_accepts_genuine_signed_module() {
+        let fx = build_artifact_binding_fixture();
+        fx.keyless_sig
+            .verify_artifact_binding(&fx.signed_module)
+            .expect("genuine signed module must verify");
+    }
+
+    /// Reproduces issue #135 exactly: flip a byte inside the signed
+    /// payload (not in the signature section), keep the signature blob
+    /// intact, assert verification rejects.
+    #[test]
+    fn test_verify_artifact_binding_rejects_byte_flipped_module() {
+        use crate::wasm_module::{Section, SectionLike, StandardSection};
+
+        let fx = build_artifact_binding_fixture();
+
+        // Tamper a byte inside the Code section's payload — well outside
+        // the signature custom section, so the signature blob still
+        // parses and the cert/Rekor checks would still succeed. We
+        // rebuild the section (rather than mutating in place) because
+        // `StandardSection`'s fields are private.
+        let tampered_sections: Vec<Section> = fx
+            .signed_module
+            .sections
+            .iter()
+            .map(|s| match s {
+                Section::Standard(std_sec) if std_sec.id() == crate::SectionId::Code => {
+                    let mut payload = std_sec.payload().to_vec();
+                    assert!(!payload.is_empty(), "Code section has bytes");
+                    payload[0] ^= 0xFF;
+                    Section::Standard(StandardSection::new(std_sec.id(), payload))
+                }
+                other => other.clone(),
+            })
+            .collect();
+        let tampered = crate::Module {
+            header: fx.signed_module.header,
+            sections: tampered_sections,
+        };
+
+        let err = fx
+            .keyless_sig
+            .verify_artifact_binding(&tampered)
+            .expect_err("tampered module must be rejected");
+        assert!(
+            matches!(err, WSError::VerificationFailed),
+            "expected VerificationFailed, got: {:?}",
+            err
+        );
+    }
+
+    /// Tampering the signature blob (not the artifact) must also be
+    /// rejected — proves the ECDSA verify leg fires even when the hash
+    /// check would pass.
+    #[test]
+    fn test_verify_artifact_binding_rejects_corrupted_signature() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered_sig = fx.keyless_sig.clone();
+        // Flip the high bit of the first signature byte — keeps the
+        // length valid (so `Signature::from_slice` succeeds) but breaks
+        // the cryptographic check.
+        tampered_sig.signature[0] ^= 0x80;
+
+        let err = tampered_sig
+            .verify_artifact_binding(&fx.signed_module)
+            .expect_err("corrupted signature must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// Pre-image attack: keep the real signature, swap the stored
+    /// `module_hash` to whatever the attacker wants the verifier to
+    /// recompute over. The hash check passes (we tampered the field to
+    /// match), but the ECDSA verify must still reject — because
+    /// `signature` was made over the genuine hash, not the substituted
+    /// one. This protects against an attacker who can recompute hashes
+    /// but not forge ECDSA signatures.
+    #[test]
+    fn test_verify_artifact_binding_rejects_substituted_module_hash() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered_sig = fx.keyless_sig.clone();
+        tampered_sig.module_hash = vec![0xAA; 32];
+
+        let err = tampered_sig
+            .verify_artifact_binding(&fx.signed_module)
+            .expect_err("hash substitution must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// Replace the leaf cert with an unrelated valid cert (different
+    /// keypair). The hash check passes (artifact unchanged), but ECDSA
+    /// verify under the new public key must fail.
+    #[test]
+    fn test_verify_artifact_binding_rejects_substituted_cert() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered_sig = fx.keyless_sig.clone();
+        tampered_sig.cert_chain = vec![fx.other_cert_pem.clone()];
+
+        let err = tampered_sig
+            .verify_artifact_binding(&fx.signed_module)
+            .expect_err("cert substitution must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
+    }
+
+    /// If the module has no signature section at all,
+    /// `verify_artifact_binding` must surface that as `NoSignatures`
+    /// rather than silently passing or returning a confusing error.
+    #[test]
+    fn test_verify_artifact_binding_rejects_module_without_signature_section() {
+        let fx = build_artifact_binding_fixture();
+        let (unsigned_module, _) = fx
+            .signed_module
+            .clone()
+            .detach_signature()
+            .expect("fixture is signed");
+
+        let err = fx
+            .keyless_sig
+            .verify_artifact_binding(&unsigned_module)
+            .expect_err("unsigned module must be rejected");
+        assert!(
+            matches!(err, WSError::NoSignatures),
+            "expected NoSignatures, got: {:?}",
+            err
+        );
+    }
+
+    /// Empty cert chain must be rejected (defense in depth — the chain
+    /// check in `verify()` already catches this, but the binding method
+    /// is a public API and must fail-closed independently).
+    #[test]
+    fn test_verify_artifact_binding_rejects_empty_cert_chain() {
+        let fx = build_artifact_binding_fixture();
+        let mut tampered_sig = fx.keyless_sig.clone();
+        tampered_sig.cert_chain.clear();
+
+        let err = tampered_sig
+            .verify_artifact_binding(&fx.signed_module)
+            .expect_err("empty cert chain must be rejected");
+        assert!(matches!(err, WSError::VerificationFailed));
     }
 }

--- a/src/lib/src/signature/keyless/signer.rs
+++ b/src/lib/src/signature/keyless/signer.rs
@@ -522,7 +522,12 @@ impl KeylessVerifier {
     ///    the leaf certificate's public key. Without this, an attacker who
     ///    obtains any valid Fulcio cert can splice a signature blob onto an
     ///    arbitrary module and the other steps will still pass (issue #135).
-    /// 5. Optionally validates identity and issuer claims
+    /// 5. **Verifies the Rekor body binding** — decodes the hashedrekord
+    ///    body and asserts its `data.hash`, `signature.content`, and
+    ///    `signature.publicKey` all match the bundle. Without this, the
+    ///    embedded Rekor entry can be any unrelated public entry and
+    ///    steps 3 and 4 still pass (issue #135 UCA-2).
+    /// 6. Optionally validates identity and issuer claims
     ///
     /// When a proof cache is configured, verified Rekor proofs are cached
     /// so that subsequent verifications can succeed during transient Rekor
@@ -633,11 +638,23 @@ impl KeylessVerifier {
         keyless_sig.verify_artifact_binding(module)?;
         log::info!("Artifact binding verified successfully");
 
-        // Step 5: Extract identity and issuer from certificate
+        // Step 5: Verify the Rekor entry's body actually references this
+        // bundle. Step 3 only proves "this Rekor entry was logged by
+        // Rekor" and step 4 only proves "this signature, cert, and module
+        // are mutually consistent" — neither proves the Rekor entry binds
+        // to *this* triple. Without this check an attacker who holds a
+        // legitimate Fulcio cert can sign a malicious module and embed
+        // any unrelated public Rekor entry to pass verification
+        // (issue #135 UCA-2).
+        log::debug!("Verifying Rekor body binding to bundle");
+        keyless_sig.verify_rekor_body_binds_to_bundle()?;
+        log::info!("Rekor body binding verified successfully");
+
+        // Step 6: Extract identity and issuer from certificate
         let identity = keyless_sig.get_identity()?;
         let issuer = keyless_sig.get_issuer()?;
 
-        // Step 6: Validate identity if expected
+        // Step 7: Validate identity if expected
         if let Some(expected) = expected_identity {
             if identity != expected {
                 return Err(WSError::CertificateError(format!(
@@ -648,7 +665,7 @@ impl KeylessVerifier {
             log::info!("Identity verified: {}", identity);
         }
 
-        // Step 7: Validate issuer if expected
+        // Step 8: Validate issuer if expected
         if let Some(expected) = expected_issuer {
             if issuer != expected {
                 return Err(WSError::CertificateError(format!(

--- a/src/lib/src/signature/keyless/signer.rs
+++ b/src/lib/src/signature/keyless/signer.rs
@@ -517,7 +517,12 @@ impl KeylessVerifier {
     /// 1. Extracts the keyless signature from the module
     /// 2. Verifies the certificate chain against Fulcio roots
     /// 3. Verifies the Rekor SET (Signed Entry Timestamp)
-    /// 4. Optionally validates identity and issuer claims
+    /// 4. **Verifies the artifact binding** — recomputes the hash of the
+    ///    stripped module and ECDSA-verifies the signature against it using
+    ///    the leaf certificate's public key. Without this, an attacker who
+    ///    obtains any valid Fulcio cert can splice a signature blob onto an
+    ///    arbitrary module and the other steps will still pass (issue #135).
+    /// 5. Optionally validates identity and issuer claims
     ///
     /// When a proof cache is configured, verified Rekor proofs are cached
     /// so that subsequent verifications can succeed during transient Rekor
@@ -617,11 +622,22 @@ impl KeylessVerifier {
             }
         }
 
-        // Step 4: Extract identity and issuer from certificate
+        // Step 4: Verify the signature actually binds to this module.
+        // This is the artifact-integrity check: recompute the hash over the
+        // bytes the signer covered (module with signature section stripped)
+        // and ECDSA-verify the signature blob against it using the leaf
+        // cert's public key. Without this, steps 2 and 3 only prove "some
+        // valid Fulcio cert exists in some Rekor entry" — they do not bind
+        // the cert to *this* artifact (issue #135).
+        log::debug!("Verifying artifact binding (hash + signature)");
+        keyless_sig.verify_artifact_binding(module)?;
+        log::info!("Artifact binding verified successfully");
+
+        // Step 5: Extract identity and issuer from certificate
         let identity = keyless_sig.get_identity()?;
         let issuer = keyless_sig.get_issuer()?;
 
-        // Step 5: Validate identity if expected
+        // Step 6: Validate identity if expected
         if let Some(expected) = expected_identity {
             if identity != expected {
                 return Err(WSError::CertificateError(format!(
@@ -632,7 +648,7 @@ impl KeylessVerifier {
             log::info!("Identity verified: {}", identity);
         }
 
-        // Step 6: Validate issuer if expected
+        // Step 7: Validate issuer if expected
         if let Some(expected) = expected_issuer {
             if issuer != expected {
                 return Err(WSError::CertificateError(format!(


### PR DESCRIPTION
## Summary

Closes #135. This branch was started as the artifact-binding fix for the original bug (one byte flipped in a signed module returned exit 0 from `wsc verify --keyless`). Once that landed, an STPA-Sec pass on the keyless verify subsystem found a second #135-class bypass at the next layer up — the embedded Rekor entry was never cross-referenced against the bundle, so any unrelated public Rekor entry would pass.

Both fixes ship in this release. The STPA report is also included so the maintainer has a durable reference for the three other open UCAs that didn't land here.

## Two security fixes (both #135-class)

### Fix 1 — Artifact binding (initial commit on this branch)

`KeylessVerifier::verify` verified the Fulcio cert chain + Rekor SET, then accepted the module without recomputing its hash or ECDSA-verifying the signature against the leaf cert. New `KeylessSignature::verify_artifact_binding` strips the signature section, recomputes SHA-256, and `verify_digest`s the signature under the leaf cert's SPKI. Wired as step 4 of `verify()`.

### Fix 2 — Rekor body binding / UCA-2 (second commit on this branch)

After fix 1, the verifier proved (cert+sig+module) were mutually consistent and (Rekor entry was logged by Rekor), but **never decoded the entry's body to check that the logged `(hash, signature, public key)` triple actually referenced this bundle**. An attacker holding any legitimate Fulcio cert could sign a malicious module and embed any unrelated public Rekor entry to pass verification:

1. Attacker obtains a legitimate Fulcio cert for their own OIDC identity (any signed-in user can).
2. Signs malicious module M' with their ephemeral key.
3. Constructs a `KeylessSignature` with their genuine sig + cert + `SHA256(M')`, embedding *any* unrelated public Rekor entry.
4. `wsc verify --keyless` returns exit 0.

The original #135 attack class re-emerges one layer up.

New `KeylessSignature::verify_rekor_body_binds_to_bundle` decodes the hashedrekord/0.0.1 body and asserts three equalities: artifact hash, signature content, and leaf-cert DER. Wired as step 5 of `verify()`.

## Tests

17 new tamper-rejection unit tests in `src/lib/src/signature/keyless/format.rs`, all passing. Coverage matrix:

| Fix 1 (artifact binding) | Fix 2 (Rekor body binding) |
|--------------------------|----------------------------|
| accept genuine signed module | accept consistent body |
| reject byte-flipped module | reject artifact-hash mismatch |
| reject corrupted signature blob | reject signature-content mismatch |
| reject substituted `module_hash` field | reject public-key mismatch |
| reject substituted leaf cert | reject unsupported `kind` |
| reject module without signature section | reject unsupported `apiVersion` |
| reject empty cert chain | reject non-sha256 hash algorithm |
| | reject garbage / non-base64 body |
| | reject non-JSON body |
| | accept uppercase hex-hash (Rekor sometimes returns these) |

Full `cargo test -p wsc`: 620 tests pass (605 lib + 5 + 5 + 5), 0 failures.

## Error variant design note

Both checks return `WSError::VerificationFailed` with a `log::error!` identifying the specific mismatch. The error variant is deliberately not discriminated (no `HashMismatch` / `SignatureInvalid` / `BodyHashMismatch` variants) — that would give an attacker an oracle to discover which leg of the check rejected their forgery while iterating. Operators get the detail via the log line.

## STPA-Sec report (new)

`docs/security/stpa-keyless-2026-05-25.md` — five UCAs identified, all independently verified against HEAD. Each UCA has a code citation, STPA-4 questions, loss scenario, suggested fix, and a verification trail (`grep` commands + file:line that confirmed the gap):

| UCA | Severity | Status | Issue |
|-----|----------|--------|-------|
| UCA-1: Rekor inclusion proof never run on verify path | High | open | (file as follow-up) |
| UCA-2: Rekor body never cross-checked with bundle | Critical | **closed by this PR** | — |
| UCA-3: Cert validity bound to attacker-pickable `integrated_time` | High (conditional) | open | (file as follow-up) |
| UCA-4: Cache hit skips SET re-verify with no bundle-equality check | Medium (conditional) | open | (file as follow-up) |
| UCA-5: Audit log records hash from silently-discarded serialize error | Low | open | (file as follow-up) |

Plus 4 speculative items the STPA explicitly couldn't confirm (multi-SAN selection, `serialize` determinism, two-signature-section asymmetry, `Module::Clone` completeness), 1 out-of-scope flag (`sct.rs` SCT verifier stub never invoked — Fulcio SCTs entirely unchecked, separate subsystem), and 7 properties explicitly cleared (skip-Rekor sentinel, chain depth bound, empty cert chain handling, negative-time rejection, etc.).

## Version + release

This PR bumps the workspace version 0.9.0 → 0.9.1 (patch release for security fixes). CHANGELOG `[0.9.1] — 2026-05-25` entry written. Once this merges, tag `v0.9.1` will trigger the release workflow.

## Downstream impact

pulseengine/synth #140 case 3 currently xfails `wsc verify --keyless` on a byte-flipped module. After this release ships, that assertion can flip back to "tampered file rejected" with no synth-side changes. (Note: synth would need a *separate* test for the UCA-2 attack — synth #140 case 3 only exercises Fix 1's behaviour.)

## Disclosure

Both UCAs are verification-bypasses in the load-bearing keyless path. Affected versions: all releases that included `KeylessVerifier::verify` (back through v0.9.0 and earlier). Recommend GHSA + RUSTSEC advisory + yank of affected versions; flagging here rather than asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)