### PR TITLE
ci(release): emit artifacts.yaml for website data auto-generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
       with:
         theme: dark
         rivet-version: v0.3.0
+        # Emit artifacts.yaml (generic-yaml) into the bundle so the website's
+        # fetch-reports can auto-generate data/sigil/{stats,artifacts}.json.
+        include-data-formats: true
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Sets `include-data-formats: true` on the rivet compliance action so the release bundle includes the generic-yaml export (`artifacts.yaml`).

The pulseengine.eu `fetch-reports` tool reads that to **auto-generate `data/sigil/{stats,artifacts}.json`** on the site — removing the last hand-maintained step for sigil's compliance numbers. One-line, additive change to an already-working compliance step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)