### PR TITLE
docs(rivet): mark shipped cybersecurity designs/verifications implemented

### DIFF
--- a/artifacts/cybersecurity/goals-and-requirements.yaml
+++ b/artifacts/cybersecurity/goals-and-requirements.yaml
@@ -781,7 +781,7 @@ artifacts:
   - id: CD-11
     type: cybersecurity-design
     title: Structured Audit Log Emitter
-    status: draft
+    status: implemented
     description: >
       JSON-structured audit log emitter producing records with timestamp,
       signer identity, module hash, key ID, Rekor UUID, and operation result
@@ -826,7 +826,7 @@ artifacts:
   - id: CV-10
     type: cybersecurity-verification
     title: Audit Log Format Verification
-    status: draft
+    status: implemented
     description: >
       Verify that audit records are JSON-structured with all required fields
       present and emitted for every sign and verify operation.
@@ -1362,7 +1362,7 @@ artifacts:
   - id: CD-20
     type: cybersecurity-design
     title: Cosign binary integrity verification before delegation
-    status: draft
+    status: implemented
     description: >
       CosignDelegator verifies cosign binary SHA-256 hash against
       expected value before subprocess invocation. Version check ensures
@@ -1374,7 +1374,7 @@ artifacts:
   - id: CD-21
     type: cybersecurity-design
     title: Tag-to-digest resolution for container signing
-    status: draft
+    status: implemented
     description: >
       ImageReference type enforces digest-bound signing by resolving
       mutable tags to immutable digests via crane/skopeo before cosign
@@ -1386,12 +1386,14 @@ artifacts:
   - id: CD-22
     type: cybersecurity-design
     title: Rekor proof cache with TTL expiry
-    status: draft
+    status: implemented
     description: >
-      MemoryProofCache stores verified Rekor inclusion proofs keyed
-      by artifact hash + Rekor UUID with configurable TTL. Thread-safe
-      via Mutex. Pluggable backend via ProofCacheBackend trait.
-      Cache is optimization-only per DD-2 fail-closed guarantee.
+      MemoryProofCache stores verified Rekor proofs keyed by artifact hash
+      plus a SHA-256 digest over the full Rekor entry content (issue #139,
+      length-prefixed: uuid, log index, body, SET, log id, integrated time,
+      inclusion proof) with configurable TTL. Thread-safe via Mutex.
+      Pluggable backend via ProofCacheBackend trait. Cache is
+      optimization-only per the fail-closed guarantee.
     links:
       - type: satisfies
         target: CR-5
@@ -1399,7 +1401,7 @@ artifacts:
   - id: CV-28
     type: cybersecurity-verification
     title: Container signing delegation tests
-    status: draft
+    status: implemented
     description: >
       20 tests covering image reference parsing, tag/digest handling,
       cosign config serialization, binary integrity checks, and
@@ -1416,7 +1418,7 @@ artifacts:
   - id: CV-29
     type: cybersecurity-verification
     title: Rekor proof cache tests
-    status: draft
+    status: implemented
     description: >
       13 tests covering cache insert/get, TTL expiry, eviction,
       invalidation, multiple entries, key serialization, and
@@ -1644,7 +1646,7 @@ artifacts:
   - id: CD-27
     type: cybersecurity-design
     title: SigstoreBundle with schema validation
-    status: draft
+    status: implemented
     description: >
       Sigstore bundle serialization with strict schema validation ensuring
       all verification material fields (certificates, inclusion proofs,
@@ -1713,7 +1715,7 @@ artifacts:
   - id: CV-34
     type: cybersecurity-verification
     title: Bundle format conformance tests
-    status: draft
+    status: implemented
     description: >
       Verify that Sigstore bundle serialization roundtrips preserve all
       fields and that schema validation rejects bundles with missing


### PR DESCRIPTION
Brings rivet artifact statuses in line with shipped code: flips 9 `cybersecurity-design`/`cybersecurity-verification` artifacts from `draft` → `implemented` now that their code + tests exist in the tree (v0.9.x).

## Flipped (each verified against real code + passing tests)

| ID | Title | Backing |
|---|---|---|
| CD-22 / CV-29 | Rekor proof cache + tests | `proof_cache.rs` (16 tests); CD-22 description also updated for the UCA-4 full-entry cache key (#139) |
| CD-11 / CV-10 | Structured audit log emitter + format verification | `src/lib/src/audit/mod.rs` |
| CD-20 / CD-21 / CV-28 | Cosign binary-integrity + tag-to-digest + tests | `container/cosign.rs`, `container/digest.rs` |
| CD-27 / CV-34 | SigstoreBundle schema validation + conformance tests | `container/bundle.rs` |

**Left `draft` deliberately** — artifacts whose own honesty-markers say design-only: PQC hybrid (CD-24/CV-31), SCT verify (CD-25/CV-32), build-env SLSA (CD-19), Nix (CD-18), transcoding (CD-17), component-model (CD-23), Cerisier research (CD-28).

## Validation — no regression

- Baseline: `FAIL (4 errors, 77 warnings, 35 broken cross-refs)`
- After: `FAIL (4 errors, 76 warnings, 35 broken)` — one fewer warning (dropped a stale prose-mention)
- The 4 errors are **pre-existing and unrelated**: `H-36/37/38` use an undeclared `related-to` link type; `CV-25` is a duplicate ID. None touch the flipped artifacts.

## Tooling friction filed upstream
- pulseengine/rivet#360 — `rivet modify` has no `--set-description` CLI flag (the `--set-field description=` error advertises a parameter only the MCP tool exposes). Workaround used here: hand-edit the YAML description.
- pulseengine/rivet#353 — corroborating comment from this sigil run + a prose-mention-rule finding (fires unactionably / on a colliding ID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)