### PR TITLE
ci(witness): wire MC/DC harness as a gating regression check (#128, #165 Track C)

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'src/lib/src/**'
       - 'src/lib/tests/**'
+      - 'src/verify-core/**'
+      - 'verification/witness-harness/**'
       - 'lean/**'
       - 'MODULE.bazel'
       - 'Cargo.toml'
@@ -18,6 +20,8 @@ on:
     paths:
       - 'src/lib/src/**'
       - 'src/lib/tests/**'
+      - 'src/verify-core/**'
+      - 'verification/witness-harness/**'
       - 'lean/**'
       - 'MODULE.bazel'
       - 'Cargo.toml'
@@ -171,3 +175,24 @@ jobs:
       # stub, not a real Rocq proof. continue-on-error stays until a `.v`
       # file is wired in.
       continue-on-error: true
+
+  # MC/DC branch-coverage gate on wsc-verify-core via the witness harness
+  # (#165 Track C / #128). Unlike the WIP proof jobs above, this is a real
+  # gate (no continue-on-error): it fails only if the MC/DC gap count rises
+  # past the committed baseline, so it cannot block on incomplete proofs —
+  # only on an actual coverage regression.
+  witness-mcdc:
+    name: Witness MC/DC gate
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    # Installs the pinned toolchain (1.94.0) from rust-toolchain.toml.
+    - name: Install pinned Rust toolchain
+      run: rustup show
+
+    - name: Run witness MC/DC regression gate
+      run: bash verification/witness-harness/witness-gate.sh
+      env:
+        # `gh release download` (to fetch the pinned witness binary) needs a token.
+        GH_TOKEN: ${{ github.token }}

--- a/verification/witness-harness/README.md
+++ b/verification/witness-harness/README.md
@@ -23,12 +23,27 @@ mechanic with crafted signed-module fixtures over `verify_multi` so the
 truth tables show MC/DC of the full verification decision logic, not just
 the varint decoder.
 
-## Running
+## CI gate
+
+[`witness-gate.sh`](witness-gate.sh) runs the whole flow below and **fails
+if the MC/DC gap count rises past the committed baseline** (`BASELINE_GAP`,
+currently 16, witness `v0.37.0`). It is wired as the gating `witness-mcdc`
+job in `.github/workflows/formal-verification.yml` (#165 Track C / #128) —
+a real gate (no `continue-on-error`), but a *regression* gate, so it cannot
+block on the still-incomplete Phase 3 coverage. Closing gaps lowers the
+count; then refresh `out/mcdc-report.txt` and `BASELINE_GAP`.
+
+```sh
+# One-shot: build + instrument + run + report + gate (auto-downloads witness)
+bash verification/witness-harness/witness-gate.sh
+```
+
+## Running manually
 
 ```sh
 # 1. Install witness (or use a checkout-local copy)
-gh release download v0.22.0 --repo pulseengine/witness \
-    --pattern '*aarch64-apple-darwin.tar.gz' --output - | tar -xz
+gh release download v0.37.0 --repo pulseengine/witness \
+    --pattern '*aarch64-apple-darwin.tar.gz' --dir . && tar -xzf witness-*.tar.gz
 export PATH="$PWD:$PATH"
 xattr -d com.apple.quarantine witness witness-viz 2>/dev/null || true
 

--- a/verification/witness-harness/README.md
+++ b/verification/witness-harness/README.md
@@ -27,7 +27,8 @@ the varint decoder.
 
 [`witness-gate.sh`](witness-gate.sh) runs the whole flow below and **fails
 if the MC/DC gap count rises past the committed baseline** (`BASELINE_GAP`,
-currently 16, witness `v0.37.0`). It is wired as the gating `witness-mcdc`
+currently 12 on the CI host, witness `v0.37.0`; ~16 on macOS/aarch64 due
+to host-dependent wasm codegen — override `BASELINE_GAP` for local runs). It is wired as the gating `witness-mcdc`
 job in `.github/workflows/formal-verification.yml` (#165 Track C / #128) —
 a real gate (no `continue-on-error`), but a *regression* gate, so it cannot
 block on the still-incomplete Phase 3 coverage. Closing gaps lowers the

--- a/verification/witness-harness/witness-gate.sh
+++ b/verification/witness-harness/witness-gate.sh
@@ -13,7 +13,12 @@
 set -euo pipefail
 
 WITNESS_VERSION="${WITNESS_VERSION:-v0.37.0}"
-BASELINE_GAP="${BASELINE_GAP:-16}"   # committed baseline; bump when gaps are closed
+# Committed baseline = the gap count on the CI host (ubuntu-latest / linux-x86_64),
+# which is the authoritative gate. NOTE: wasm codegen is mildly host-dependent —
+# the same toolchain+witness yields ~16 gaps on macOS/aarch64 vs 12 on linux/x86_64
+# (the instrumented .wasm differs by a few bytes). Lower this when #128's Phase 3
+# fixtures close gaps. Override via the BASELINE_GAP env var for local runs.
+BASELINE_GAP="${BASELINE_GAP:-12}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 cd "$HERE"
 

--- a/verification/witness-harness/witness-gate.sh
+++ b/verification/witness-harness/witness-gate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# witness MC/DC regression gate for wsc-verify-core (#165 Track C / #128).
+#
+# Rebuilds the harness, instruments it with a pinned `witness` release, runs
+# the fixed scenario set, and fails if the number of MC/DC *gap* conditions
+# has INCREASED past the committed baseline. Improvements (fewer gaps) pass
+# and should be followed by refreshing out/mcdc-report.txt + BASELINE_GAP.
+#
+# Why gap-count and not a byte-diff of the report: wasm codegen / witness
+# row ordering can differ across hosts and witness versions; the gap count
+# is the meaningful, stable MC/DC signal (the skill's "read the gap rows,
+# not the coverage percentage").
+set -euo pipefail
+
+WITNESS_VERSION="${WITNESS_VERSION:-v0.37.0}"
+BASELINE_GAP="${BASELINE_GAP:-16}"   # committed baseline; bump when gaps are closed
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
+
+# --- resolve a `witness` binary (use PATH, else download the pinned release) ---
+if command -v witness >/dev/null 2>&1; then
+  WIT="$(command -v witness)"
+else
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)   ASSET="witness-${WITNESS_VERSION}-x86_64-unknown-linux-gnu.tar.gz" ;;
+    Darwin-arm64)   ASSET="witness-${WITNESS_VERSION}-aarch64-apple-darwin.tar.gz" ;;
+    Darwin-x86_64)  ASSET="witness-${WITNESS_VERSION}-x86_64-apple-darwin.tar.gz" ;;
+    *) echo "::error:: unsupported host $(uname -s)-$(uname -m) for witness download"; exit 2 ;;
+  esac
+  TMP="$(mktemp -d)"
+  gh release download "$WITNESS_VERSION" --repo pulseengine/witness \
+     --pattern "$ASSET" --dir "$TMP"
+  tar -xzf "$TMP/$ASSET" -C "$TMP"
+  WIT="$(find "$TMP" -name witness -type f | head -1)"
+  chmod +x "$WIT"
+fi
+echo "Using $("$WIT" --version)"
+
+# --- build the harness for the instrumentable wasm target ---
+rustup target add wasm32-wasip1 >/dev/null 2>&1 || true
+cargo build --target wasm32-wasip1
+WASM="target/wasm32-wasip1/debug/wsc_witness_harness.wasm"
+
+# --- instrument + run the fixed scenario set + report ---
+mkdir -p out
+"$WIT" instrument "$WASM" -o out/instrumented.wasm
+"$WIT" run out/instrumented.wasm \
+  --invoke-with-args 'decode_varint_5:1,0,0,0,0' \
+  --invoke-with-args 'decode_varint_5:128,1,0,0,0' \
+  --invoke-with-args 'decode_varint_5:128,128,1,0,0' \
+  --invoke-with-args 'decode_varint_5:128,128,128,1,0' \
+  --invoke-with-args 'decode_varint_5:128,128,128,128,1' \
+  --invoke-with-args 'decode_varint_5:128,128,128,128,128' \
+  --invoke-with-args 'try_parse_wasm:0,97,115,109,1,0,0,0' \
+  --invoke-with-args 'try_parse_wasm:255,97,115,109,1,0,0,0' \
+  --invoke-with-args 'try_parse_wasm:0,255,115,109,1,0,0,0' \
+  --invoke-with-args 'try_parse_wasm:0,97,255,109,1,0,0,0' \
+  --invoke-with-args 'try_parse_wasm:0,97,115,255,1,0,0,0' \
+  --invoke-with-args 'try_parse_wasm:0,97,115,109,255,0,0,0' \
+  --invoke-with-args 'try_parse_wasm:0,0,0,0,0,0,0,0' \
+  -o out/run.json
+"$WIT" report --input out/run.json --format mcdc | tee out/mcdc-report.txt
+
+# --- gate: gap count must not exceed the committed baseline ---
+GAP="$(grep -oE '[0-9]+ gap' out/mcdc-report.txt | head -1 | grep -oE '[0-9]+')"
+echo "MC/DC gap conditions: ${GAP} (baseline ${BASELINE_GAP})"
+if [ "${GAP:-9999}" -gt "$BASELINE_GAP" ]; then
+  echo "::error:: MC/DC regression — gap conditions rose ${BASELINE_GAP} -> ${GAP}. A verification decision lost coverage; add a scenario or restore the branch."
+  exit 1
+fi
+if [ "${GAP}" -lt "$BASELINE_GAP" ]; then
+  echo "::notice:: MC/DC improved (${BASELINE_GAP} -> ${GAP}); refresh out/mcdc-report.txt and BASELINE_GAP to lock it in."
+fi
+echo "witness MC/DC gate: OK"


### PR DESCRIPTION
sigil ships a witness MC/DC harness with committed output but **never ran it in CI** (#165 Track C). This wires it as the gating `witness-mcdc` job in the Formal Verification workflow.

## What

- **`verification/witness-harness/witness-gate.sh`** — builds the harness for `wasm32-wasip1`, instruments with a pinned witness release (`v0.37.0`, auto-downloaded for the host), runs the fixed varint + wasm-header scenario set, and **fails if the MC/DC gap count rises past the committed baseline (16)**.
- **`formal-verification.yml`** — new `witness-mcdc` job. A **real gate** (no `continue-on-error`), but a *regression* gate: it can't block on the still-open Phase 3 coverage, only on a coverage **loss**. Triggers extended to `src/verify-core/**` + `verification/witness-harness/**`.

## Why gap-count, not a byte-diff

wasm codegen / witness row ordering can vary across hosts and witness versions; the gap count is the stable, meaningful MC/DC signal (the skill's "read the gap rows, not the coverage percentage"). Locally: gap 16 == baseline 16, gate passes.

## Scope vs #128 / #165

- **#128** (Phase 3 `verify_multi` MC/DC coverage — the 16 open gaps) stays **open**: this PR gates against *regression*, it does not close those gaps. When #128 lands fixtures that close gaps, lower `BASELINE_GAP`.
- **#165 Track A (SBOM)** is **already done** — v0.9.3 shipped `wsc-0.9.3.cdx.json` (added by #134, covered by signed `SHA256SUMS` + SLSA provenance). This PR is **Track C**. npm/scry tracks remain for the hub (pulseengine.eu#98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)