### PR TITLE
plan(embedded): rivet plan + cross-repo links for on-target trust chain (#187)

### DIFF
--- a/artifacts/dev/features.yaml
+++ b/artifacts/dev/features.yaml
@@ -495,3 +495,54 @@ artifacts:
       of all component sections during the signing process.
     fields:
       phase: phase-2
+
+  - id: FEAT-12
+    type: feature
+    title: "Embedded on-target trust chain: no_std verifier + signed kiln.resource_limits (reject-at-load)"
+    status: draft
+    tags: [embedded, no_std, kiln, gale, trust-chain]
+    fields:
+      description: "On-target (thumbv7em-none-eabi, gale/gust) offline key-based verification so kiln's loader can trust the signed kiln.resource_limits bounds for reject-at-load. Reuses kiln's existing ResourceLimitsSection (already no_std/bounded) and sigil's existing key-based Ed25519 path in wsc-verify-core; HW-crypto via the wsc:crypto hardware interface provided by gale. Tracks #187; kiln#415/AD-WCMC-001."
+    links:
+      - type: traces-to
+        target: EXTERNALANCHOR-001
+
+  - id: REQ-15
+    type: requirement
+    title: no_std wsc-verify-core staticlib for thumbv7em-none-eabi (secure-boot verify)
+    status: draft
+    tags: [embedded, no_std]
+    fields:
+      description: "Carve wsc-verify-core to #![no_std]+alloc behind a default 'std' feature so the host CLI is unaffected. Feature-gate file-IO (std::fs/os::unix/env::temp_dir/Path ~30 uses); replace std::io::Read/Cursor (~18) with a slice reader; alloc collections + core::fmt. Ship a thumbv7em-none-eabi staticlib mirroring kiln-async. Deps already no_std-viable (spike). Key-based Ed25519 verify (signature/multi.rs,simple.rs) becomes on-target reachable. Enabling release for #187."
+      release: v0.10.0
+    links:
+      - type: traces-to
+        target: FEAT-12
+
+      - type: traces-to
+        target: DD-8
+  - id: REQ-16
+    type: requirement
+    title: Signed reject-at-load of kiln.resource_limits (bounds covered by whole-module signature)
+    status: draft
+    tags: [embedded, kiln, secure-boot]
+    fields:
+      description: "Reuse kiln's existing ResourceLimitsSection (kiln.resource_limits v1, already no_std/BoundedMap). sigil's whole-module signed hash already covers it (only the sig section is stripped). Pipeline: kiln embed_limits -> sigil signs -> target verifies. Verify+loader MUST reject if signature invalid OR section absent OR signed bounds (max_memory_usage/max_call_depth/...) exceed the provisioned RAM/stack budget. Hooks kiln's extract_resource_limits_from_binary / resource_limits_loader. Closes the 'trust an unsigned size claim' gap in #187."
+      release: v0.11.0
+    links:
+      - type: traces-to
+        target: FEAT-12
+
+      - type: traces-to
+        target: DD-8
+  - id: DD-8
+    type: design-decision
+    title: "Embedded secure-boot verify profile: key-based Ed25519, HW-preferred with SW fallback"
+    status: draft
+    tags: [embedded, secure-boot, crypto]
+    fields:
+      description: "Embedded verify profile decision for #187 / kiln#415 (AD-WCMC-001)."
+      rationale: "Secure-boot path (reject-at-load = boot-admission gate) on air-gapped gale/gust: keyless is impossible offline (needs network), so verification must be KEY-BASED with embedded public keys. Crypto is HW-where-possible via gale's wsc:crypto hardware interface (accelerated Ed25519 verify / secure key storage), SW fallback ed25519-compact where the BSP lacks it; verify uses only public keys so the SW fallback is correctness-complete without a secure element. Spike 2026-07-11 confirmed ed25519-compact+ct-codecs build no_std for thumbv7em-none-eabi."
+    links:
+      - type: traces-to
+        target: EXTERNALANCHOR-001

--- a/artifacts/external-anchors.yaml
+++ b/artifacts/external-anchors.yaml
@@ -1,0 +1,12 @@
+artifacts:
+
+  - id: EXTERNALANCHOR-001
+    type: external-anchor
+    title: gale OS/BSP/HW-crypto boundary (embedded verify) — awaiting gale#164
+    status: draft
+    tags: [embedded, gale, supplier-boundary]
+    fields:
+      description: "Supplier boundary: gale provides OS/BSP + optional HW Ed25519 verify + embedded trust-anchor public-key provisioning for the on-target secure-boot verify (FEAT-12/DD-8). gale has no rivet store yet; chain intentionally not followed past here. Tracked at gale#164; flip received-status when they respond ('when it arrives')."
+      expected-derived-types: hardware-verify-impl,trust-anchor-provisioning,bsp-nostd-contract
+      received-status: not-received
+      source-of-truth: repo:gale

--- a/docs/embedded/on-target-trust-chain.md
+++ b/docs/embedded/on-target-trust-chain.md
@@ -1,0 +1,93 @@
+# Embedded on-target trust chain (#187) — plan & coordination drafts
+
+Status: **planning**. Tracks sigil #187, kiln #415 / `AD-WCMC-001`.
+Rivet: `FEAT-12` → `REQ-15` (no_std verify-core, v0.10.0), `REQ-16` (signed
+reject-at-load, v0.11.0), `DD-8` (secure-boot verify profile).
+
+## The pipeline (a secure-boot path)
+
+```
+meld → scry (sound bounds) → kiln.resource_limits (embed) → sigil signs
+     → embedded verify (no_std, offline, key-based) → reject-at-load → run
+```
+
+`reject-at-load` is the **boot-admission gate**: a module whose signed bounds
+exceed the provisioned RAM/stack budget is refused on the bench, not trapped
+mid-mission. The gate is only trustworthy if the target *trusts* the bound —
+hence on-target signature verification.
+
+## What already exists (so we build less than the issue assumes)
+
+- **Key-based verify** (ask #3): `wsc-verify-core` already has the non-keyless
+  Ed25519 public-key path (`signature/{multi,simple,keys}.rs`). std today.
+- **The bounds format** (ask #2): kiln's `ResourceLimitsSection`
+  (`kiln.resource_limits` v1) is already `no_std`/`BoundedMap`-bounded
+  (`max_memory_usage`, `max_call_depth` [ASIL-D-required], `max_fuel_per_step`,
+  `qualification_hash`, …). sigil signs the **whole module minus the sig
+  section**, so this section is already covered by the signature. No new
+  manifest format — reuse kiln's.
+- **HW-crypto proposal**: sigil's `wsc:crypto` `hardware-signing` WIT
+  (handle-based, key material stays in the secure element; ed25519/ecdsa;
+  security-levels software→hardware-certified). gale would implement it.
+
+## Spike result (2026-07-11) — ask #1 de-risked
+
+`ed25519-compact` + `ct-codecs` (both `default-features = false`) build for
+`thumbv7em-none-eabi` in `no_std` and expose the public-key verify API. So the
+dependency wall is clear; ask #1 reduces to sigil's own std→no_std refactor:
+feature-gate file-IO (`std::fs`/`os::unix`/`env::temp_dir`/`Path`, ~30 uses),
+swap `std::io::Read`/`Cursor` (~18) for a slice reader, `alloc` collections +
+`core::fmt`. Ship a `thumbv7em` staticlib mirroring kiln-async.
+
+## Crypto strategy: HW-preferred, SW-fallback (DD-8)
+
+- **HW where possible**: gale's `wsc:crypto` implementation (accelerated Ed25519
+  verify / secure key storage) when the BSP provides it.
+- **SW fallback**: `ed25519-compact` software verify. Verify uses **only public
+  keys** — no secret material — so the SW fallback is *correctness-complete*
+  without a secure element. HW buys speed (Cortex-M Ed25519 verify is costly)
+  and key-storage assurance, not correctness.
+
+## Release mapping
+
+| Release | Scope |
+|---|---|
+| sigil **v0.10.0** | `no_std` carve of verify-core behind a default `std` feature; `thumbv7em-none-eabi` staticlib in CI; key-based verify reachable no_std (`REQ-15`). |
+| sigil **v0.11.0** | require-signed-`kiln.resource_limits` + reject-at-load contract; integration test against kiln's loader (`REQ-16`). |
+
+---
+
+## DRAFT — comment for kiln #415 / AD-WCMC-001 (review before posting)
+
+> sigil-side plan for the on-target trust chain is in sigil#187 (rivet FEAT-12).
+> Key points for the loader integration:
+> - **We reuse `kiln.resource_limits` verbatim** — no new manifest format. sigil's
+>   whole-module signature already covers the section (only the sig custom
+>   section is stripped before hashing), so the bounds are signed as-is.
+> - **Integration point**: `resource_limits_loader` /
+>   `extract_resource_limits_from_binary` should call sigil's (no_std) verify
+>   **before** trusting the section. Proposed contract — the loader rejects if:
+>   (a) the module signature is invalid, OR (b) the `kiln.resource_limits`
+>   section is absent, OR (c) the signed bounds exceed the provisioned
+>   RAM/stack budget.
+> - **Pipeline ordering** matters: `cargo-kiln embed_limits` must run **before**
+>   sigil signs, so the bounds are inside the signed hash. Can we confirm
+>   `embed_limits` is a pre-sign build step?
+> - sigil ships a `thumbv7em-none-eabi` staticlib (v0.10.0) for you to link,
+>   mirroring kiln-async's no_std staticlib.
+
+## DRAFT — issue/question for gale (review before posting; gale not checked out locally)
+
+> For the gale/gust embedded secure-boot path (sigil#187, kiln#415), sigil needs
+> to verify module signatures **on-target, offline, key-based**. Questions:
+> 1. **HW-accelerated Ed25519 verify?** Does the BSP expose a crypto accelerator
+>    for Ed25519 *verify* (public-key; no secret material)? If so we'd bind it
+>    through sigil's `wsc:crypto` interface (extended with a `hardware-verify`
+>    counterpart to the existing `hardware-signing`). If not, the software
+>    `ed25519-compact` path is correctness-complete — HW is a perf/assurance
+>    upgrade, not required.
+> 2. **Trust-anchor provisioning**: where do the embedded verification **public
+>    keys** live (gale secure storage / a provisioned key region)? The verifier
+>    needs the trust anchor at load time.
+> 3. **OS/BSP surface**: what `no_std` environment does the `thumbv7em` staticlib
+>    link against (allocator present? which `core`/`alloc` assumptions)?

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -23,6 +23,13 @@ externals:
   synth:
     path: ../synth
     prefix: synth
+  # kiln owns the resource-limits section + on-board loader for the embedded
+  # trust chain (FEAT-12 / #187 ← kiln#415, AD-WCMC-001). Cross-repo linkable.
+  kiln:
+    path: ../kiln
+    prefix: kiln
+  # gale (OS/BSP/HW-crypto) has no rivet setup yet — link via gale#164 for now;
+  # add as an external here when it gains rivet artifacts ("when it arrives").
 
 commits:
   format: trailers


### PR DESCRIPTION
Planning + de-risk for the embedded secure-boot trust chain (#187 ← kiln#415/AD-WCMC-001). Proposals posted: **kiln#421** (loader integration), **gale#164** (crypto/BSP).

## Rivet plan (FEAT-12)
- **REQ-15** — no_std `wsc-verify-core` staticlib for `thumbv7em-none-eabi` (v0.10.0)
- **REQ-16** — signed reject-at-load of `kiln.resource_limits` (v0.11.0)
- **DD-8** — secure-boot verify profile: key-based Ed25519, HW-preferred / SW-fallback

## Cross-repo links
- `rivet.yaml`: **kiln** added as an external (`../kiln`, prefix `kiln`) for direct artifact linking. **gale** deferred ("when it arrives" — no rivet store yet).
- **EXTERNALANCHOR-001**: gale OS/BSP/HW-crypto supplier boundary (`received-status: not-received`, tracked gale#164), linked from FEAT-12/DD-8.

## De-risk
`docs/embedded/on-target-trust-chain.md` — full plan + **no_std spike (2026-07-11)**: `ed25519-compact` + `ct-codecs` (`default-features=false`) build `no_std` for `thumbv7em-none-eabi` with public-key verify working. Ask #1's dependency wall is clear.

Planning only — no verifier code changes. Feasibility is strong because #129 already carved verify-core TLS/X.509-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)