### PR TITLE
fix(release): sign wsc-cli.wasm (wasip2) as a hard requirement — #164 stale

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,23 +245,21 @@ jobs:
         # Create a detached signature for verification
         mv wsc-component.signed.wasm wsc-component.wasm
 
-        # Sign the CLI WASM if it exists and is a parseable core module / component.
-        # The CLI WASM is built with wasm32-wasip2 which produces a format that
-        # wsc's own parser does not currently recognize. This is a known limitation
-        # and the CLI WASM is an optional artifact, so we tolerate sign failures.
+        # Sign the CLI WASM if the wasip2 build produced it. wsc's parser
+        # DOES handle the wasm32-wasip2 component format (verified 2026-07:
+        # sign + verify round-trip on a real 3.98 MB component with an
+        # embedded core module — #164), and wsc-component.wasm (also wasip2)
+        # is already signed unconditionally above. So this is a HARD
+        # requirement: a sign failure fails the release loudly instead of
+        # silently dropping the unsigned artifact (no continue-on-error theatre).
         if [ -f wsc-cli.wasm ]; then
           echo "Signing wsc-cli.wasm..."
-          if ./target/release/wsc sign --keyless \
-               --input-file wsc-cli.wasm \
-               --output-file wsc-cli.signed.wasm; then
-            mv wsc-cli.signed.wasm wsc-cli.wasm
-            echo "  ✅ wsc-cli.wasm signed"
-          else
-            echo "  ⚠️  wsc-cli.wasm could not be signed (parser does not yet"
-            echo "      support the wasm32-wasip2 output format). Removing"
-            echo "      unsigned CLI artifact from release."
-            rm -f wsc-cli.wasm wsc-cli.signed.wasm
-          fi
+          ./target/release/wsc sign --keyless \
+            --input-file wsc-cli.wasm \
+            --output-file wsc-cli.signed.wasm \
+            || { echo "::error::wsc-cli.wasm (wasm32-wasip2) failed to sign — component-parser regression (#164)"; exit 1; }
+          mv wsc-cli.signed.wasm wsc-cli.wasm
+          echo "  ✅ wsc-cli.wasm signed"
         fi
 
         echo "✅ WASM files signed with wsc (keyless)"


### PR DESCRIPTION
**#164's parser blocker is stale — verified empirically.**

## Evidence (clean-room, didn't trust the issue or the code comment)
- Key-based `wsc sign` + `verify` round-trip on a **real 3.98 MB wasip2 component** (123 sections incl. the 3.96 MB embedded core module) → *"Signature is valid."*
- Same on a clean `wasm-tools`-built component.
- `wsc-component.wasm` (also wasip2) is **already signed unconditionally** in this job, every release.
- The earlier "Parse error" was a confounder: that file was *already keyless-signed*, so re-signing tripped on the existing signature section — not component parsing. #129's `Extension(u8)` handling works on real components.

## Change
Drop the stale `tolerate + rm unsigned` fallback and the outdated "parser does not recognize wasip2" comment. `wsc-cli.wasm` is now signed as a **hard requirement** — a sign failure fails the release loudly (parser-regression guard) instead of silently dropping the artifact. CI is the oracle for the literal artifact (local Bazel build was blocked by an unrelated jco/npm timeout).

Closes #164. Unblocks agora#3 and the org-wide wasm-signing standard (#165).

🤖 Generated with [Claude Code](https://claude.com/claude-code)