### PR TITLE
plan(embedded): REQ-18 dep → ordeal v0.13.0 (re-sequenced)

### DIFF
--- a/artifacts/dev/features.yaml
+++ b/artifacts/dev/features.yaml
@@ -567,7 +567,7 @@ artifacts:
     status: draft
     tags: [embedded, verification, ordeal, soundness]
     fields:
-      description: "Prove wasm_module/varint.rs overflow/bounds (bvmul/bvadd at widths 8/32/64, QF_BV) with ordeal for a cert.recheck()-able certificate, upgrading #88 from Kani-bounded to a machine-checkable proof. varint.rs is in wsc-verify-core = the on-target parser (REQ-15), so this hardens the secure-boot admission path: witness MC/DC (#169) + overflow certificate on the same code. Boundary is honest QF_BV only; Ed25519 (#145/#32) and Rekor Merkle (#137) are out of fragment. Gated on ordeal prove_valid API (ordeal#66, v0.12.0); additive, no urgency. Certificate later becomes a gating CI check + a rivet-typed certificate artifact per ordeal#67."
+      description: "Prove wasm_module/varint.rs overflow/bounds (bvmul/bvadd at widths 8/32/64, QF_BV) with ordeal for a cert.recheck()-able certificate, upgrading #88 from Kani-bounded to a machine-checkable proof. varint.rs is in wsc-verify-core = the on-target parser (REQ-15), so this hardens the secure-boot admission path: witness MC/DC (#169) + overflow certificate on the same code. Boundary is honest QF_BV only; Ed25519 (#145/#32) and Rekor Merkle (#137) are out of fragment. Gated on ordeal prove_valid API (ordeal#66, v0.13.0 — re-sequenced from v0.12.0 per ordeal#80, loom#70 prioritized); additive, no urgency. Certificate later becomes a gating CI check + a rivet-typed certificate artifact per ordeal#67."
     links:
       - type: traces-to
         target: FEAT-12


### PR DESCRIPTION
ordeal#66 (`prove_valid`) re-sequenced v0.12.0 → v0.13.0 (ordeal#80; loom#70 prioritized). REQ-18 (varint overflow certificate) is additive/non-blocking, so the slip is harmless — just updating the tracked dependency. Noted sigil/REQ-18 as a prospective `prove_valid` consumer on ordeal#66. Planning only.