### PR TITLE
fix(bazel): bare @wsc_deps//:ureq alias — unbreaks the release (ureq 3.1.2→3.3.0 drift)

### DIFF
--- a/src/cli/BUILD.bazel
+++ b/src/cli/BUILD.bazel
@@ -42,7 +42,7 @@ rust_binary(
          "@wsc_deps//:env_logger",
          "@wsc_deps//:regex",
          "@wsc_deps//:serde_json",
-         "@wsc_deps//:ureq-3.1.2",
+         "@wsc_deps//:ureq",
          "@wsc_deps//:wasi",
      ],
     # No feature flags needed - HTTP client selected via #[cfg(target_os = "wasi")]

--- a/src/lib/BUILD.bazel
+++ b/src/lib/BUILD.bazel
@@ -52,7 +52,7 @@ rust_library(
         "@wsc_deps//:serde_json",
         "@wsc_deps//:spki",
         "@wsc_deps//:time",
-        "@wsc_deps//:ureq-3.1.2",
+        "@wsc_deps//:ureq",
         "@wsc_deps//:webpki-roots",
         "@wsc_deps//:x509-parser",
          # Certificate provisioning dependencies


### PR DESCRIPTION
The release + every wasm-component build aborts at Bazel analysis:
```
ERROR: no such target '@wsc_deps//:ureq-3.1.2' (did you mean ureq-3.3.0?)
  referenced by //src/lib:wsc
```
ureq was the **only** dep referenced with a version-suffixed crate_universe target; all others use the bare alias. crate_universe re-pinned ureq `^3.1.2` → 3.3.0, so `ureq-3.1.2` vanished. Switch both `src/lib/BUILD.bazel` and `src/cli/BUILD.bazel` to the bare `@wsc_deps//:ureq` alias (matches every other dep; drift-proof).

**Note on the 'sign then verify' symptom:** this aborts the wasm build *before* the sign/verify round-trip, so signing was never the failure — it's a Cargo↔Bazel dep drift. Once the build is green again the release reaches the sign/verify step (a hard requirement since #192, so any real signature issue would surface loudly).