### PR TITLE
fix(parser): raise MAX_SLICE_LEN to 256MB — large wasip2 components sign (#164, unbreaks release)

### DIFF
--- a/src/verify-core/src/wasm_module/varint.rs
+++ b/src/verify-core/src/wasm_module/varint.rs
@@ -56,11 +56,21 @@ pub fn put_slice(writer: &mut impl Write, bytes: impl AsRef<[u8]>) -> Result<(),
     Ok(())
 }
 
-/// Maximum size for a length-prefixed slice (16 MB)
+/// Maximum size for a length-prefixed slice (256 MB)
 ///
 /// This limit prevents denial-of-service attacks via malformed length prefixes
-/// that could cause excessive memory allocation.
-pub const MAX_SLICE_LEN: usize = 16 * 1024 * 1024;
+/// that could cause excessive memory allocation. It must be large enough to
+/// hold a WASM **component's** embedded core-module section: a full CLI built
+/// for `wasm32-wasip2` (e.g. `wsc-cli.wasm`) embeds a core module far larger
+/// than the old 16 MB bound, which rejected it with a spurious `ParseError`
+/// at sign time (#164). 256 MB is generous headroom for any realistic
+/// component while still bounding a single allocation on the host.
+///
+/// NOTE: the embedded verifier profile (REQ-15) wants a tighter, input-bounded
+/// read (cap the allocation by the actual remaining input, not a fixed
+/// constant) so a malformed length prefix cannot allocate on a constrained
+/// target — tracked with the no_std carve.
+pub const MAX_SLICE_LEN: usize = 256 * 1024 * 1024;
 
 pub fn get_slice(reader: &mut impl Read) -> Result<Vec<u8>, CoreError> {
     let len = get32(reader)? as usize;


### PR DESCRIPTION
**The real #164 bug** — and the actual cause of the failing release. My earlier close (#192) was premature; #192 only *surfaced* it (hard-requirement → loud failure instead of silent drop).

## What happened
2026-08-05 release (after the ureq/#212 build fix): reached the sign step. `wsc-component.wasm` (3.96MB) signed fine; **`wsc-cli.wasm` → "Parse error"**.

## Root cause
`Section::deserialize` rejects any section payload > `MAX_SLICE_LEN` (16MB). A wasm **component's embedded core-module section** for a full `wasm32-wasip2` CLI exceeds 16MB. Reproduced with a synthetic >16MB-section module (ParseError → signs+verifies at 256MB).

## Fix
Raise `MAX_SLICE_LEN` 16MB → 256MB. Generous for any realistic component, still bounds a single host allocation. Excessive-length rejection still holds (test value > 256MB). **166 verify-core tests pass**; big-section + small-module sign/verify round-trips confirmed locally. Tighter input-bounded read noted as embedded-profile (REQ-15) follow-up.

Closes #164 (for real this time). Unblocks the release sign step + agora#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)