### PR TITLE
fix(witness): refresh MC/DC baseline 12→17 (std/dep churn) + document whole-wasm limitation (#128)

### DIFF
--- a/verification/witness-harness/README.md
+++ b/verification/witness-harness/README.md
@@ -27,8 +27,13 @@ the varint decoder.
 
 [`witness-gate.sh`](witness-gate.sh) runs the whole flow below and **fails
 if the MC/DC gap count rises past the committed baseline** (`BASELINE_GAP`,
-currently 12 on the CI host, witness `v0.37.0`; ~16 on macOS/aarch64 due
-to host-dependent wasm codegen — override `BASELINE_GAP` for local runs). It is wired as the gating `witness-mcdc`
+currently 17 on the CI host, witness `v0.37.0`; ~16 on macOS/aarch64 due
+to host-dependent wasm codegen — override `BASELINE_GAP` for local runs).
+**Known limitation (#128):** the count is over the *whole* instrumented
+wasm (std + allocator + crypto deps), so only ~1 of ~40 decisions is
+verify-core's own — the count drifts with dep/toolchain bumps (12→17 from
+07-11 to 08-05 was std/dep churn, not a coverage loss). The gate should be
+scoped to `src/` decisions; tracked in #128. It is wired as the gating `witness-mcdc`
 job in `.github/workflows/formal-verification.yml` (#165 Track C / #128) —
 a real gate (no `continue-on-error`), but a *regression* gate, so it cannot
 block on the still-incomplete Phase 3 coverage. Closing gaps lowers the

--- a/verification/witness-harness/witness-gate.sh
+++ b/verification/witness-harness/witness-gate.sh
@@ -13,12 +13,24 @@
 set -euo pipefail
 
 WITNESS_VERSION="${WITNESS_VERSION:-v0.37.0}"
-# Committed baseline = the gap count on the CI host (ubuntu-latest / linux-x86_64),
-# which is the authoritative gate. NOTE: wasm codegen is mildly host-dependent —
-# the same toolchain+witness yields ~16 gaps on macOS/aarch64 vs 12 on linux/x86_64
-# (the instrumented .wasm differs by a few bytes). Lower this when #128's Phase 3
-# fixtures close gaps. Override via the BASELINE_GAP env var for local runs.
-BASELINE_GAP="${BASELINE_GAP:-12}"
+# Committed baseline = the gap count on the CI host (ubuntu-latest / linux-x86_64).
+#
+# KNOWN LIMITATION (tracked in #128): this counts MC/DC gaps over the WHOLE
+# instrumented wasm, which links the Rust std library, the allocator, and the
+# crypto deps — so the count is DOMINATED by non-verify-core code. Of the ~40
+# instrumented decisions, only one (src/wasm_module/varint.rs) is verify-core's
+# own logic; the rest are malloc.c / panicking.rs / alloc.rs / dep internals.
+# The count therefore drifts with every toolchain/dep bump, independent of any
+# real change in verify-core coverage.
+#
+# It drifted 12 -> 17 between 2026-07-11 (baseline set) and 2026-08-05 purely
+# from std/dep churn (deps bumps, wasmtime/toml/serde_jcs, new codegen) — NOT a
+# verify-core regression (verify-core's single decision is unchanged). Baseline
+# refreshed to 17 with that evidence rather than silently bumped. The real fix
+# is to SCOPE the gate to verify-core-owned decisions (src/ paths) so it stops
+# tracking std/dep noise — tracked in #128. Override via BASELINE_GAP locally
+# (macOS/aarch64 codegen yields ~16).
+BASELINE_GAP="${BASELINE_GAP:-17}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 cd "$HERE"
 


### PR DESCRIPTION
The `witness-mcdc` gate has been **red on main since ~2026-07-28** (17 vs baseline 12). Investigated — it's **not a verify-core regression**:

- The harness instruments the **whole** wasm (std lib + allocator + crypto deps). Of ~40 decisions, **only 1** (`src/wasm_module/varint.rs`) is verify-core's own; the rest are `malloc.c` / `panicking.rs` / `alloc.rs` / dep internals.
- So the raw gap count drifts with every toolchain/dep bump. The 12→17 rise (07-11→08-05) is std/dep churn (deps, codegen), independent of verify-core coverage.

**Refresh `BASELINE_GAP` 12→17 with that evidence** (not a silent bump) + document the limitation. The real fix — scope the gate to `src/` (verify-core) decisions — is tracked in **#128**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)