### PR TITLE
release: v0.9.4 — unbreak release + real #164 fix (sign large wasip2 components)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to sigil are documented here. The project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] — 2026-08-05
+
+Release-integrity fixes. Unbreaks the release pipeline and lands the *real*
+fix for signing sigil's own `wasm32-wasip2` CLI — the genuine #164 bug that
+v0.9.3's #192 workaround only surfaced.
+
+### Fixed
+
+- **Sign large wasm32-wasip2 components (#164 / #213).** `wsc sign`/`verify`
+  rejected `wsc-cli.wasm` with "Parse error": a wasm **component** embeds its
+  core module as a single section, and a full CLI's exceeds the old 16 MB
+  `MAX_SLICE_LEN` bound in `Section::deserialize`. Raised to 256 MB — generous
+  for any realistic component, still bounds a single host allocation; the
+  excessive-length rejection is unchanged (its test value exceeds 256 MB).
+  Reproduced with a synthetic >16 MB-section module; the release now runs
+  build → sign → **verify** → publish green, so `wsc-cli.wasm` ships signed.
+  (`wsc-component.wasm`, 3.96 MB, always fit — only the larger CLI tripped it.)
+  Unblocks the org-wide wasm-signing standard (#165) and agora#3.
+  *Falsification:* a wasm component whose embedded core module is ≤ 256 MB now
+  signs and verifies; one whose bounds/signature are tampered still rejects.
+- **Bazel `ureq` dep drift (#212).** The wasm-component build aborted at
+  analysis (`no such target '@wsc_deps//:ureq-3.1.2'`) after crate_universe
+  re-pinned `ureq ^3.1.2 → 3.3.0`. `ureq` was the only dep pinned to a
+  version-suffixed target; switched both BUILD files to the bare
+  `@wsc_deps//:ureq` alias (matches every other dep, drift-proof).
+
+### Changed
+
+- **Witness MC/DC gate baseline 12 → 17 (#214 / #128).** The gate had been red
+  on `main` since ~2026-07-28 from std/dep/toolchain churn — the count is over
+  the *whole* instrumented wasm (only ~1 of ~40 decisions is verify-core's own),
+  so it drifts with dep bumps rather than tracking real coverage. Baseline
+  refreshed with that evidence documented (not a silent bump); the sound fix —
+  scoping the gate to `src/` decisions — is tracked in #128.
+- Dependency and CI-action bumps accumulated since v0.9.3 (wasmtime 47,
+  toml 1.1, serde_jcs 0.2, wit-bindgen 0.51, actions v7/v8, …).
+
 ## [0.9.3] — 2026-06-23
 
 Dependency-maintenance release. Bumps the dependency and CI-action set to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,27 +433,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b374d3a9cbec48a5bdefa88cd3e55459319b06075f10c128876b7dec25da493e"
+checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20250f55b050732e0cead176e2f7dd23721282ee8366836fc877cf6ac25ccc33"
+checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ff547421e17d09340d61c09065043a6485b18c651b4eab80de3d3446a10889"
+checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994d63dd3c34dfbc051d06d1d346520de9a44ad8b98c6ebb223fdbb723c7691f"
+checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
 dependencies = [
  "serde",
  "serde_derive",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400748ae61b3b9c6f198a9ca94035c77ffdaf12fc11ab45a5a250e38cbb2314b"
+checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c227694acecbfbbad69adcf576b6cedb4c456228edd588bfb22c9a7b4331ec9f"
+checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -516,24 +516,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea30af1582f89202e3b35a5f5b58de17fd4e237430b3e57546b87aafb74bd4f"
+checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
 
 [[package]]
 name = "cranelift-control"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54214ea93b2f227567c56bf98e363239591af8c53716678d3fe741549aa2e52b"
+checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37240456300f0ac5a6d4fc06360f9486c1bd98b56a6c3252bd77fe4b51f6f72a"
+checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b5a840f761ab4096ec5c88e09b8c3bbd788912608f7c1dde85ae8bde5ad133"
+checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.0",
@@ -556,15 +556,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "932eb4a8a2cc24c55c4f11829a102254e9edf7f44dc7764b232c80494628c50c"
+checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
 
 [[package]]
 name = "cranelift-native"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f757e7af29533480f8e662faaadf8c491c0c7c3c6b27d80c95a17c0f54712895"
+checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.134.1"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711bd5976a9cdeae1a8f74ed43d0a5c8b96f1d46b9c242f132a3aab408e9d7cf"
+checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
 
 [[package]]
 name = "crc32fast"
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -928,7 +928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1569,7 +1569,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1897,7 +1897,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b54ec63c3295549cc4561d73a29cb83819704646ef489cae0ad437e30e18167"
+checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afeb29aa3e850e05e5019133cd331cdb901edfec3455ff441f0fe66a14e1296"
+checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2792,7 +2792,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3187,7 +3187,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3936,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52eccae7b639f124e474bc8fc052c11e5709143fba02a09ca6c0c2ee3903152"
+checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -3989,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c1cc5d238f59a62c5083208e4092e4770eceaaa8def4686c3412bc234703a9"
+checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -4020,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af161f18c43031b75969d7e3a89cc38855d1b3a8cb1814cc385f18f82de383c9"
+checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
 dependencies = [
  "base64",
  "directories-next",
@@ -4040,9 +4040,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55723606968f063d2c16dbdb82ee0bf6bbc6db283504cc5578f5dc7cdbf75d1e"
+checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4055,15 +4055,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b083b0b746d9f3bec33323f5f15e9407d74c78d9f635bb156eb03934899859"
+checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a34315bfd55a70ca52630bb1b0bcd834c455b5017ee1789d34f7d690d0696c0"
+checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -4073,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1900c0379077c30f5ffe8f66d9803c43ef8f91ae790718113099fbd245bd226"
+checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4100,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28065260eb11e36765721a5001da5a807705a8181396dcdcb113c919a1719a7a"
+checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4115,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d5b0d21932765a25a5f82826aa61a3324e3683ae2086e9f9fe7dfc7fa11477"
+checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
 dependencies = [
  "cc",
  "object",
@@ -4127,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66acb694c19ed2214bb8513d259cac8c27407c4c8a72551d80b723339ef35a91"
+checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4139,9 +4139,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2899faa12f7e9d5761164aa96522f03d29796097b2a70274341888eb6555f282"
+checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4152,9 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e655193dc7a8684d17cb255730419608b087197af5c5af4875c39554b3be99"
+checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4163,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "47.0.1"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b68ccf03917702ed7e8521e75ee9776c078ed291c76b2d235e49e980d88aa"
+checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4259,7 +4259,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4628,7 +4628,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsc"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-attestation"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "base64",
  "chrono",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "clap",
  "env_logger",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-component"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "wit-bindgen 0.51.0",
  "wsc",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "wsc-verify-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "ct-codecs",
  "ed25519-compact",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 authors = ["Frank Denis <github@pureftpd.org>", "Ralf Anton Beier <ralf_beier@me.com>"]
 license = "MIT"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@
 module(
     name = "wsc",
     # Keep in sync with [workspace.package].version in Cargo.toml.
-    version = "0.9.0",
+    version = "0.9.4",
 )
 
 # Dependencies

--- a/artifacts/dev/features.yaml
+++ b/artifacts/dev/features.yaml
@@ -587,3 +587,23 @@ artifacts:
     links:
       - type: traces-to
         target: FEAT-12
+
+  - id: DD-10
+    type: design-decision
+    title: MAX_SLICE_LEN = 256MB to hold a wasm component's embedded core-module section
+    status: implemented
+    tags: [parser, component, sign]
+    fields:
+      description: "Decision behind the #213 fix that unblocks wasm32-wasip2 component signing (#164)."
+      rationale: A wasm32-wasip2 component embeds a whole core module as one section; a full CLI (wsc-cli.wasm) exceeds the old 16MB bound, so Section::deserialize rejected it with ParseError at sign time (#164). 256MB is generous headroom for any realistic component while still bounding a single host allocation; the excessive-length rejection still holds (test value exceeds 256MB). Tighter input-bounded read deferred to the embedded profile (REQ-15).
+
+  - id: REQ-19
+    type: requirement
+    title: sigil signs + verifies wasm32-wasip2 components with large embedded core modules
+    status: implemented
+    tags: [sign, component, release]
+    fields:
+      description: "wsc sign/verify must round-trip on wasm32-wasip2 COMPONENTS (not just core modules), including a full CLI whose embedded core module exceeds 16MB. Oracle: sign then verify a >16MB-section component returns valid (reproduced locally + green release run build->sign->verify->publish). Unblocks the org-wide wasm-signing standard (#165) and agora#3. Implements #164."
+    links:
+      - type: traces-to
+        target: DD-10

--- a/src/cli/BUILD.bazel
+++ b/src/cli/BUILD.bazel
@@ -15,7 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 # Version info - keep in sync with [workspace.package].version in Cargo.toml
 # and with the `version` field in MODULE.bazel.
-VERSION = "0.9.0"
+VERSION = "0.9.4"
 
 rust_binary(
     name = "wasmsign_cli",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -32,5 +32,5 @@ regex = "1.12.2"
 # HTTP client for keyless signing
 ureq = { version = "3.1.2" }
 wasi = { version = "0.14.7" }
-wsc = { version = "0.9.3", path = "../lib" }
+wsc = { version = "0.9.4", path = "../lib" }
 serde_json = "1.0"

--- a/src/component/Cargo.toml
+++ b/src/component/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Core signing library
-wsc = { version = "0.9.3", path = "../lib" }
+wsc = { version = "0.9.4", path = "../lib" }
 
 # WIT bindings generation
 wit-bindgen = { version = "0.51.0", default-features = false, features = ["realloc"] }

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["cryptography", "wasm"]
 [dependencies]
 # Verification core (carved out so it builds for wasm32 with no TLS/X.509 deps).
 # wsc re-exports its public API for backwards compatibility.
-wsc-verify-core = { version = "0.9.3", path = "../verify-core" }
+wsc-verify-core = { version = "0.9.4", path = "../verify-core" }
 # Re-export attestation types from minimal crate
-wsc-attestation = { version = "0.9.3", path = "../attestation" }
+wsc-attestation = { version = "0.9.4", path = "../attestation" }
 anyhow = "1.0.100"
 ct-codecs = "1.1.6"
 ed25519-compact = { version = "2.1.1", features = ["pem"] }


### PR DESCRIPTION
Ships the release-integrity fixes now on main as **v0.9.4**:

- **#213** — `MAX_SLICE_LEN` 16MB→256MB so `wsc-cli.wasm` (large embedded core module) signs+verifies (the real #164 bug; rivet REQ-19/DD-10).
- **#212** — bare `@wsc_deps//:ureq` Bazel alias (dep drift unbroke the build).
- **#214** — witness MC/DC baseline 12→17 (documented std/dep churn; #128).
- accumulated dep/action bumps since v0.9.3.

**Verified:** release run build→sign→**verify**→publish green; 609 lib tests pass; Kani varint proof holds; witness gate green (17==17). Clean-room verification of the release claims in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)